### PR TITLE
Persist diagram data when updating and use port 80

### DIFF
--- a/README.md
+++ b/README.md
@@ -99,7 +99,7 @@ VITE_OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> npm run build
 ### Run the Docker Container
 
 ```bash
-docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -v chartdb-data:/data -p 8080:3000 ghcr.io/chartdb/chartdb:latest
+docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -v chartdb-data:/data -p 8080:80 ghcr.io/chartdb/chartdb:latest
 ```
 
 The container stores diagrams under `/data`. Mount a volume at this path to keep diagrams between restarts.
@@ -108,7 +108,7 @@ The container stores diagrams under `/data`. Mount a volume at this path to keep
 
 ```bash
 docker build -t chartdb .
-docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -v chartdb-data:/data -p 8080:3000 chartdb
+docker run -e OPENAI_API_KEY=<YOUR_OPEN_AI_KEY> -v chartdb-data:/data -p 8080:80 chartdb
 ```
 
 #### Using Custom Inference Server
@@ -125,7 +125,7 @@ docker run \
   -e OPENAI_API_ENDPOINT=<YOUR_ENDPOINT> \
   -e LLM_MODEL_NAME=<YOUR_MODEL_NAME> \
   -v chartdb-data:/data \
-  -p 8080:3000 chartdb
+  -p 8080:80 chartdb
 ```
 
 > **Privacy Note:** ChartDB includes privacy-focused analytics via Fathom Analytics. You can disable this by adding `-e DISABLE_ANALYTICS=true` to the run command or `--build-arg VITE_DISABLE_ANALYTICS=true` when building.

--- a/server.js
+++ b/server.js
@@ -72,7 +72,15 @@ app.post('/api/diagrams/:id', async (req, res) => {
             });
         }
 
-        const diagram = { id: req.params.id, ...req.body };
+        let existing = {};
+        try {
+            const data = await fs.readFile(file, 'utf-8');
+            existing = JSON.parse(data);
+        } catch {
+            // ignore missing file or invalid JSON
+        }
+
+        const diagram = { ...existing, id: req.params.id, ...req.body };
         await fs.writeFile(file, JSON.stringify(diagram, null, 2));
         res.json({ ok: true });
     } catch (e) {
@@ -142,5 +150,5 @@ app.delete('/api/diagram-filters/:id', async (req, res) => {
     }
 });
 
-const port = process.env.PORT || 3000;
+const port = process.env.PORT || 80;
 app.listen(port, () => console.log(`Server running on ${port}`));


### PR DESCRIPTION
## Summary
- preserve existing diagram content when updating diagrams
- default server port to 80 and update documentation

## Testing
- `npm test -- --run`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af2a706b6c832c9f7a516f2aa95d77