### PR TITLE
Use atomic file write when saving diagrams

### DIFF
--- a/server.js
+++ b/server.js
@@ -81,7 +81,20 @@ app.post('/api/diagrams/:id', async (req, res) => {
         }
 
         const diagram = { ...existing, id: req.params.id, ...req.body };
-        await fs.writeFile(file, JSON.stringify(diagram, null, 2));
+
+        const tmpFile = `${file}.tmp`;
+        await fs.writeFile(tmpFile, JSON.stringify(diagram, null, 2));
+        await fs.rename(tmpFile, file);
+
+        try {
+            const data = await fs.readFile(file, 'utf-8');
+            JSON.parse(data);
+        } catch {
+            return res
+                .status(500)
+                .json({ error: 'Failed to verify saved diagram' });
+        }
+
         res.json({ ok: true });
     } catch (e) {
         res.status(500).json({ error: e.message });


### PR DESCRIPTION
## Summary
- Write diagram updates to a temporary file and atomically replace the original
- Verify saved JSON by reading and parsing after rename

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68af31847048832cb22a6d6ec64446d2