### PR TITLE
feat(server): deep merge diagram updates

### DIFF
--- a/server.js
+++ b/server.js
@@ -16,6 +16,22 @@ const ensureDir = async (dir) => {
     await fs.mkdir(dir, { recursive: true });
 };
 
+const deepMerge = (target, source) => {
+    for (const key of Object.keys(source)) {
+        const srcVal = source[key];
+        const tgtVal = target[key];
+        if (srcVal && typeof srcVal === 'object' && !Array.isArray(srcVal)) {
+            target[key] = deepMerge(
+                tgtVal && typeof tgtVal === 'object' ? { ...tgtVal } : {},
+                srcVal
+            );
+        } else {
+            target[key] = srcVal;
+        }
+    }
+    return target;
+};
+
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'dist')));
 
@@ -80,7 +96,7 @@ app.post('/api/diagrams/:id', async (req, res) => {
             // ignore missing file or invalid JSON
         }
 
-        const diagram = { ...existing, id: req.params.id, ...req.body };
+        const diagram = deepMerge({ ...existing, id: req.params.id }, req.body);
         await fs.writeFile(file, JSON.stringify(diagram, null, 2));
         res.json({ ok: true });
     } catch (e) {
@@ -151,4 +167,8 @@ app.delete('/api/diagram-filters/:id', async (req, res) => {
 });
 
 const port = process.env.PORT || 80;
-app.listen(port, () => console.log(`Server running on ${port}`));
+if (process.env.NODE_ENV !== 'test') {
+    app.listen(port, () => console.log(`Server running on ${port}`));
+}
+
+export default app;

--- a/server.test.ts
+++ b/server.test.ts
@@ -1,0 +1,71 @@
+// @vitest-environment node
+import { describe, it, expect, beforeEach, afterEach } from 'vitest';
+import fs from 'fs/promises';
+import path from 'path';
+import os from 'os';
+import { once } from 'events';
+import type { AddressInfo } from 'net';
+
+let server;
+let baseUrl;
+let tempDir;
+
+beforeEach(async () => {
+    tempDir = await fs.mkdtemp(path.join(os.tmpdir(), 'diagram-test-'));
+    process.env.DIAGRAMS_PATH = tempDir;
+    process.env.NODE_ENV = 'test';
+    const { default: app } = await import('./server.js');
+    server = app.listen(0);
+    await once(server, 'listening');
+    const { port } = server.address() as AddressInfo;
+    baseUrl = `http://127.0.0.1:${port}`;
+});
+
+afterEach(async () => {
+    await new Promise((resolve) => server.close(resolve));
+    await fs.rm(tempDir, { recursive: true, force: true });
+    delete process.env.DIAGRAMS_PATH;
+    delete process.env.NODE_ENV;
+});
+
+describe('POST /api/diagrams/:id deep merge', () => {
+    it('preserves existing tables and relationships on partial update', async () => {
+        const id = 'test';
+        const initial = {
+            name: 'Diagram',
+            databaseType: 'mysql',
+            createdAt: '2024-01-01',
+            updatedAt: '2024-01-01',
+            tables: { t1: { id: 't1', name: 'Table1' } },
+            relationships: { r1: { id: 'r1', name: 'Rel1' } },
+        };
+        let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(initial),
+        });
+        expect(res.status).toBe(200);
+
+        const update = {
+            name: 'Diagram',
+            databaseType: 'mysql',
+            createdAt: '2024-01-01',
+            updatedAt: '2024-01-02',
+            tables: { t2: { id: 't2', name: 'Table2' } },
+            relationships: { r2: { id: 'r2', name: 'Rel2' } },
+        };
+        res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(update),
+        });
+        expect(res.status).toBe(200);
+
+        res = await fetch(`${baseUrl}/api/diagrams/${id}`);
+        const diagram = await res.json();
+        expect(diagram.tables).toHaveProperty('t1');
+        expect(diagram.tables).toHaveProperty('t2');
+        expect(diagram.relationships).toHaveProperty('r1');
+        expect(diagram.relationships).toHaveProperty('r2');
+    });
+});


### PR DESCRIPTION
## Summary
- deep merge diagram updates to preserve nested tables and relationships
- export Express app and gate server startup for tests
- cover partial update behavior for diagrams

## Testing
- `CI=1 npm test`


------
https://chatgpt.com/codex/tasks/task_e_68af31857120832c974d62382f07529e