### PR TITLE
fix: remove stray whitespace in server.js

### DIFF
--- a/server.js
+++ b/server.js
@@ -95,11 +95,9 @@ app.post('/api/diagrams/:id', async (req, res) => {
         } catch {
             // ignore missing file or invalid JSON
         }
-
-      
         const diagram = deepMerge({ ...existing, id: req.params.id }, req.body);
         const tmpFile = `${file}.tmp`;
-      
+
         await fs.writeFile(tmpFile, JSON.stringify(diagram, null, 2));
         await fs.rename(tmpFile, file);
 
@@ -111,7 +109,6 @@ app.post('/api/diagrams/:id', async (req, res) => {
                 .status(500)
                 .json({ error: 'Failed to verify saved diagram' });
         }
-
 
         res.json({ ok: true });
     } catch (e) {


### PR DESCRIPTION
## Summary
- fix server.js extra whitespace causing prettier lint errors

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68af783f5548832cb987b5ecdf7b46aa