### PR TITLE
Ensure diagram JSON includes all arrays

### DIFF
--- a/server.js
+++ b/server.js
@@ -32,6 +32,21 @@ const deepMerge = (target, source) => {
     return target;
 };
 
+const normalizeDiagram = (diagram) => {
+    diagram.tables = Array.isArray(diagram.tables) ? diagram.tables : [];
+    diagram.relationships = Array.isArray(diagram.relationships)
+        ? diagram.relationships
+        : [];
+    diagram.dependencies = Array.isArray(diagram.dependencies)
+        ? diagram.dependencies
+        : [];
+    diagram.areas = Array.isArray(diagram.areas) ? diagram.areas : [];
+    diagram.customTypes = Array.isArray(diagram.customTypes)
+        ? diagram.customTypes
+        : [];
+    return diagram;
+};
+
 app.use(express.json());
 app.use(express.static(path.join(__dirname, 'dist')));
 
@@ -50,7 +65,7 @@ app.get('/api/diagrams', async (_req, res) => {
                     if (!diagram.id) {
                         diagram.id = path.basename(f, '.json');
                     }
-                    return diagram;
+                    return normalizeDiagram(diagram);
                 })
         );
         res.json(diagrams);
@@ -67,7 +82,7 @@ app.get('/api/diagrams/:id', async (req, res) => {
         if (!diagram.id) {
             diagram.id = path.basename(file, '.json');
         }
-        res.json(diagram);
+        res.json(normalizeDiagram(diagram));
     } catch {
         res.status(404).end();
     }
@@ -95,7 +110,9 @@ app.post('/api/diagrams/:id', async (req, res) => {
         } catch {
             // ignore missing file or invalid JSON
         }
-        const diagram = deepMerge({ ...existing, id: req.params.id }, req.body);
+        const diagram = normalizeDiagram(
+            deepMerge({ ...existing, id: req.params.id }, req.body)
+        );
         const tmpFile = `${file}.tmp`;
 
         await fs.writeFile(tmpFile, JSON.stringify(diagram, null, 2));

--- a/server.test.ts
+++ b/server.test.ts
@@ -36,8 +36,17 @@ describe('POST /api/diagrams/:id deep merge', () => {
             databaseType: 'mysql',
             createdAt: '2024-01-01',
             updatedAt: '2024-01-01',
-            tables: { t1: { id: 't1', name: 'Table1' } },
-            relationships: { r1: { id: 'r1', name: 'Rel1' } },
+            tables: [{ id: 't1', name: 'Table1' }],
+            relationships: [
+                {
+                    id: 'r1',
+                    name: 'Rel1',
+                    sourceTableId: 't1',
+                    targetTableId: 't1',
+                    sourceFieldId: 'f1',
+                    targetFieldId: 'f1',
+                },
+            ],
         };
         let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
             method: 'POST',
@@ -51,8 +60,6 @@ describe('POST /api/diagrams/:id deep merge', () => {
             databaseType: 'mysql',
             createdAt: '2024-01-01',
             updatedAt: '2024-01-02',
-            tables: { t2: { id: 't2', name: 'Table2' } },
-            relationships: { r2: { id: 'r2', name: 'Rel2' } },
         };
         res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
             method: 'POST',
@@ -63,9 +70,35 @@ describe('POST /api/diagrams/:id deep merge', () => {
 
         res = await fetch(`${baseUrl}/api/diagrams/${id}`);
         const diagram = await res.json();
-        expect(diagram.tables).toHaveProperty('t1');
-        expect(diagram.tables).toHaveProperty('t2');
-        expect(diagram.relationships).toHaveProperty('r1');
-        expect(diagram.relationships).toHaveProperty('r2');
+        expect(diagram.tables).toHaveLength(1);
+        expect(diagram.tables[0].id).toBe('t1');
+        expect(diagram.relationships).toHaveLength(1);
+        expect(diagram.relationships[0].id).toBe('r1');
+    });
+});
+
+describe('POST /api/diagrams/:id array defaults', () => {
+    it('ensures array fields are present when omitted', async () => {
+        const id = 'arr-test';
+        const minimal = {
+            name: 'Diagram',
+            databaseType: 'mysql',
+            createdAt: '2024-01-01',
+            updatedAt: '2024-01-01',
+        };
+
+        let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
+            method: 'POST',
+            headers: { 'Content-Type': 'application/json' },
+            body: JSON.stringify(minimal),
+        });
+        expect(res.status).toBe(200);
+
+        res = await fetch(`${baseUrl}/api/diagrams/${id}`);
+        const diagram = await res.json();
+        expect(Array.isArray(diagram.tables)).toBe(true);
+        expect(Array.isArray(diagram.dependencies)).toBe(true);
+        expect(Array.isArray(diagram.areas)).toBe(true);
+        expect(Array.isArray(diagram.customTypes)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- normalize diagrams on save/load so tables, relationships, dependencies, areas and custom types are always arrays
- add tests confirming array fields persist and are returned when omitted in requests

## Testing
- `npx vitest run --reporter=dot`


------
https://chatgpt.com/codex/tasks/task_e_68af7c6984dc832ca7119ae9d4d850bc