### PR TITLE
Fix JSON save missing nested arrays

### DIFF
--- a/server.js
+++ b/server.js
@@ -33,7 +33,13 @@ const deepMerge = (target, source) => {
 };
 
 const normalizeDiagram = (diagram) => {
-    diagram.tables = Array.isArray(diagram.tables) ? diagram.tables : [];
+    diagram.tables = Array.isArray(diagram.tables)
+        ? diagram.tables.map((table) => ({
+              ...table,
+              fields: Array.isArray(table.fields) ? table.fields : [],
+              indexes: Array.isArray(table.indexes) ? table.indexes : [],
+          }))
+        : [];
     diagram.relationships = Array.isArray(diagram.relationships)
         ? diagram.relationships
         : [];
@@ -42,7 +48,11 @@ const normalizeDiagram = (diagram) => {
         : [];
     diagram.areas = Array.isArray(diagram.areas) ? diagram.areas : [];
     diagram.customTypes = Array.isArray(diagram.customTypes)
-        ? diagram.customTypes
+        ? diagram.customTypes.map((customType) => ({
+              ...customType,
+              values: Array.isArray(customType.values) ? customType.values : [],
+              fields: Array.isArray(customType.fields) ? customType.fields : [],
+          }))
         : [];
     return diagram;
 };

--- a/server.test.ts
+++ b/server.test.ts
@@ -85,6 +85,8 @@ describe('POST /api/diagrams/:id array defaults', () => {
             databaseType: 'mysql',
             createdAt: '2024-01-01',
             updatedAt: '2024-01-01',
+            tables: [{ id: 't1', name: 'Table1' }],
+            customTypes: [{ id: 'ct1', name: 'Type1', kind: 'enum' }],
         };
 
         let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
@@ -100,5 +102,9 @@ describe('POST /api/diagrams/:id array defaults', () => {
         expect(Array.isArray(diagram.dependencies)).toBe(true);
         expect(Array.isArray(diagram.areas)).toBe(true);
         expect(Array.isArray(diagram.customTypes)).toBe(true);
+        expect(Array.isArray(diagram.tables[0].fields)).toBe(true);
+        expect(Array.isArray(diagram.tables[0].indexes)).toBe(true);
+        expect(Array.isArray(diagram.customTypes[0].values)).toBe(true);
+        expect(Array.isArray(diagram.customTypes[0].fields)).toBe(true);
     });
 });


### PR DESCRIPTION
## Summary
- ensure table field and index arrays and custom type arrays are normalized when saving diagrams
- test server stores default arrays for tables and custom types

## Testing
- `npx vitest run server.test.ts`

------
https://chatgpt.com/codex/tasks/task_e_68af83950798832c99a0571ac18a809d