### PR TITLE
Fix JSON save missing nested arrays

### DIFF
--- a/server.test.ts
+++ b/server.test.ts
@@ -28,8 +28,8 @@ afterEach(async () => {
     delete process.env.NODE_ENV;
 });
 
-describe('POST /api/diagrams/:id deep merge', () => {
-    it('preserves existing tables and relationships on partial update', async () => {
+describe('POST /api/diagrams/:id overwrite', () => {
+    it('replaces existing data when fields are omitted', async () => {
         const id = 'test';
         const initial = {
             name: 'Diagram',
@@ -37,16 +37,6 @@ describe('POST /api/diagrams/:id deep merge', () => {
             createdAt: '2024-01-01',
             updatedAt: '2024-01-01',
             tables: [{ id: 't1', name: 'Table1' }],
-            relationships: [
-                {
-                    id: 'r1',
-                    name: 'Rel1',
-                    sourceTableId: 't1',
-                    targetTableId: 't1',
-                    sourceFieldId: 'f1',
-                    targetFieldId: 'f1',
-                },
-            ],
         };
         let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
             method: 'POST',
@@ -70,10 +60,7 @@ describe('POST /api/diagrams/:id deep merge', () => {
 
         res = await fetch(`${baseUrl}/api/diagrams/${id}`);
         const diagram = await res.json();
-        expect(diagram.tables).toHaveLength(1);
-        expect(diagram.tables[0].id).toBe('t1');
-        expect(diagram.relationships).toHaveLength(1);
-        expect(diagram.relationships[0].id).toBe('r1');
+        expect(diagram.tables).toHaveLength(0);
     });
 });
 
@@ -85,6 +72,8 @@ describe('POST /api/diagrams/:id array defaults', () => {
             databaseType: 'mysql',
             createdAt: '2024-01-01',
             updatedAt: '2024-01-01',
+            tables: [{ id: 't1', name: 'Table1' }],
+            customTypes: [{ id: 'ct1', name: 'Type1', kind: 'enum' }],
         };
 
         let res = await fetch(`${baseUrl}/api/diagrams/${id}`, {
@@ -100,5 +89,57 @@ describe('POST /api/diagrams/:id array defaults', () => {
         expect(Array.isArray(diagram.dependencies)).toBe(true);
         expect(Array.isArray(diagram.areas)).toBe(true);
         expect(Array.isArray(diagram.customTypes)).toBe(true);
+        expect(Array.isArray(diagram.tables[0].fields)).toBe(true);
+        expect(Array.isArray(diagram.tables[0].indexes)).toBe(true);
+        expect(Array.isArray(diagram.customTypes[0].values)).toBe(true);
+        expect(Array.isArray(diagram.customTypes[0].fields)).toBe(true);
+    });
+});
+
+describe('POST /api/diagrams/:id concurrent saves', () => {
+    it('does not corrupt data when requests overlap', async () => {
+        const id = 'race';
+        const payloadA = {
+            name: 'A',
+            databaseType: 'mysql',
+            createdAt: '2024-01-01',
+            updatedAt: '2024-01-01',
+            tables: [{ id: 'ta', name: 'TA' }],
+        };
+        const payloadB = {
+            name: 'B',
+            databaseType: 'mysql',
+            createdAt: '2024-01-01',
+            updatedAt: '2024-01-01',
+            tables: [{ id: 'tb', name: 'TB' }],
+        };
+
+        const [resA, resB] = await Promise.all([
+            fetch(`${baseUrl}/api/diagrams/${id}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payloadA),
+            }),
+            fetch(`${baseUrl}/api/diagrams/${id}`, {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify(payloadB),
+            }),
+        ]);
+        expect(resA.status).toBe(200);
+        expect(resB.status).toBe(200);
+
+        const res = await fetch(`${baseUrl}/api/diagrams/${id}`);
+        const diagram = await res.json();
+
+        expect(diagram.tables).toHaveLength(1);
+        const tableId = diagram.tables[0].id;
+        if (tableId === 'ta') {
+            expect(diagram.name).toBe('A');
+        } else if (tableId === 'tb') {
+            expect(diagram.name).toBe('B');
+        } else {
+            throw new Error('unexpected table id');
+        }
     });
 });


### PR DESCRIPTION
## Summary
- save diagrams by writing normalized request bodies directly, mirroring export-json behaviour
- test overwriting diagrams and preserving array defaults without data corruption

## Testing
- `npx vitest run server.test.ts`


------
https://chatgpt.com/codex/tasks/task_e_68af83950798832c99a0571ac18a809d