### PR TITLE
feat: expose modify diagram helper

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -62,7 +62,10 @@ app.put('/diagram/:id', async (req, res) => {
         await fs.mkdir(DATA_DIR, { recursive: true });
         const diagram = { ...req.body, id: req.params.id };
         const json = JSON.stringify(diagram, null, 2);
-        await fs.writeFile(diagramFile(req.params.id), json);
+        const filePath = diagramFile(req.params.id);
+        const tempPath = `${filePath}.tmp`;
+        await fs.writeFile(tempPath, json, 'utf-8');
+        await fs.rename(tempPath, filePath);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save');
@@ -94,7 +97,10 @@ app.put('/config', async (req, res) => {
     try {
         await fs.mkdir(DATA_DIR, { recursive: true });
         const json = JSON.stringify(req.body, null, 2);
-        await fs.writeFile(path.join(DATA_DIR, 'config.json'), json);
+        const filePath = path.join(DATA_DIR, 'config.json');
+        const tempPath = `${filePath}.tmp`;
+        await fs.writeFile(tempPath, json, 'utf-8');
+        await fs.rename(tempPath, filePath);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save config');

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -292,12 +292,10 @@ export const ChartDBProvider: React.FC<
             setTables((currentTables) => [...currentTables, ...tablesToAdd]);
             const updatedAt = new Date();
             setDiagramUpdatedAt(updatedAt);
-            await Promise.all([
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
-                ...tablesToAdd.map((table) =>
-                    db.addTable({ diagramId, table })
-                ),
-            ]);
+            await db.modifyDiagram(diagramId, (d) => {
+                d.tables = [...(d.tables ?? []), ...tablesToAdd];
+                d.updatedAt = updatedAt;
+            });
 
             events.emit({
                 action: 'add_tables',

--- a/src/context/storage-context/storage-context.tsx
+++ b/src/context/storage-context/storage-context.tsx
@@ -45,6 +45,10 @@ export interface StorageContext {
         id: string;
         attributes: Partial<Diagram>;
     }) => Promise<void>;
+    modifyDiagram: (
+        diagramId: string,
+        modifyFn: (diagram: Diagram) => void
+    ) => Promise<void>;
     deleteDiagram: (id: string) => Promise<void>;
 
     // Table operations
@@ -149,6 +153,7 @@ export const storageInitialValue: StorageContext = {
     listDiagrams: emptyFn,
     getDiagram: emptyFn,
     updateDiagram: emptyFn,
+    modifyDiagram: emptyFn,
     deleteDiagram: emptyFn,
 
     addTable: emptyFn,

--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -547,6 +547,7 @@ export const StorageProvider: React.FC<React.PropsWithChildren> = ({
                 getDiagram,
                 updateDiagram,
                 deleteDiagram,
+                modifyDiagram,
                 addTable,
                 getTable,
                 updateTable,


### PR DESCRIPTION
## Summary
- expose `modifyDiagram` helper in storage context
- atomically update diagrams when adding tables using `modifyDiagram`
- replace diagram and config file writes with atomic temp file swaps to avoid JSON corruption

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9f2bfc4832c80147d7eae1e3ca8