### PR TITLE
feat: expose modify diagram helper

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -62,7 +62,10 @@ app.put('/diagram/:id', async (req, res) => {
         await fs.mkdir(DATA_DIR, { recursive: true });
         const diagram = { ...req.body, id: req.params.id };
         const json = JSON.stringify(diagram, null, 2);
-        await fs.writeFile(diagramFile(req.params.id), json);
+        const filePath = diagramFile(req.params.id);
+        const tempPath = `${filePath}.tmp`;
+        await fs.writeFile(tempPath, json, 'utf-8');
+        await fs.rename(tempPath, filePath);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save');
@@ -94,7 +97,10 @@ app.put('/config', async (req, res) => {
     try {
         await fs.mkdir(DATA_DIR, { recursive: true });
         const json = JSON.stringify(req.body, null, 2);
-        await fs.writeFile(path.join(DATA_DIR, 'config.json'), json);
+        const filePath = path.join(DATA_DIR, 'config.json');
+        const tempPath = `${filePath}.tmp`;
+        await fs.writeFile(tempPath, json, 'utf-8');
+        await fs.rename(tempPath, filePath);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save config');

--- a/src/context/chartdb-context/chartdb-provider.tsx
+++ b/src/context/chartdb-context/chartdb-provider.tsx
@@ -292,12 +292,10 @@ export const ChartDBProvider: React.FC<
             setTables((currentTables) => [...currentTables, ...tablesToAdd]);
             const updatedAt = new Date();
             setDiagramUpdatedAt(updatedAt);
-            await Promise.all([
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
-                ...tablesToAdd.map((table) =>
-                    db.addTable({ diagramId, table })
-                ),
-            ]);
+            await db.modifyDiagram(diagramId, (d) => {
+                d.tables = [...(d.tables ?? []), ...tablesToAdd];
+                d.updatedAt = updatedAt;
+            });
 
             events.emit({
                 action: 'add_tables',
@@ -1055,30 +1053,31 @@ export const ChartDBProvider: React.FC<
 
     const addRelationships: ChartDBContext['addRelationships'] = useCallback(
         async (
-            relationships: DBRelationship[],
+            relationshipsToAdd: DBRelationship[],
             options = { updateHistory: true }
         ) => {
             setRelationships((currentRelationships) => [
                 ...currentRelationships,
-                ...relationships,
+                ...relationshipsToAdd,
             ]);
 
             const updatedAt = new Date();
             setDiagramUpdatedAt(updatedAt);
 
-            await Promise.all([
-                ...relationships.map((relationship) =>
-                    db.addRelationship({ diagramId, relationship })
-                ),
-                db.updateDiagram({ id: diagramId, attributes: { updatedAt } }),
-            ]);
+            await db.modifyDiagram(diagramId, (d) => {
+                d.relationships = [
+                    ...(d.relationships ?? []),
+                    ...relationshipsToAdd,
+                ];
+                d.updatedAt = updatedAt;
+            });
 
             if (options.updateHistory) {
                 addUndoAction({
                     action: 'addRelationships',
-                    redoData: { relationships },
+                    redoData: { relationships: relationshipsToAdd },
                     undoData: {
-                        relationshipIds: relationships.map((r) => r.id),
+                        relationshipIds: relationshipsToAdd.map((r) => r.id),
                     },
                 });
                 resetRedoStack();

--- a/src/context/history-context/history-provider.tsx
+++ b/src/context/history-context/history-provider.tsx
@@ -174,11 +174,9 @@ export const HistoryProvider: React.FC<React.PropsWithChildren> = ({
             removeTables: async ({
                 undoData: { tables, relationships, dependencies },
             }) => {
-                await Promise.all([
-                    addTables(tables, { updateHistory: false }),
-                    addRelationships(relationships, { updateHistory: false }),
-                    addDependencies(dependencies, { updateHistory: false }),
-                ]);
+                await addTables(tables, { updateHistory: false });
+                await addRelationships(relationships, { updateHistory: false });
+                await addDependencies(dependencies, { updateHistory: false });
             },
             updateTable: ({ undoData: { tableId, table } }) => {
                 return updateTable(tableId, table, { updateHistory: false });
@@ -229,14 +227,12 @@ export const HistoryProvider: React.FC<React.PropsWithChildren> = ({
             updateTablesState: async ({
                 undoData: { tables, relationships, dependencies },
             }) => {
-                await Promise.all([
-                    updateTablesState(() => tables, {
-                        updateHistory: false,
-                        forceOverride: true,
-                    }),
-                    addRelationships(relationships, { updateHistory: false }),
-                    addDependencies(dependencies, { updateHistory: false }),
-                ]);
+                await updateTablesState(() => tables, {
+                    updateHistory: false,
+                    forceOverride: true,
+                });
+                await addRelationships(relationships, { updateHistory: false });
+                await addDependencies(dependencies, { updateHistory: false });
             },
             addIndex: ({ undoData: { tableId, indexId } }) => {
                 return removeIndex(tableId, indexId, { updateHistory: false });

--- a/src/context/storage-context/storage-context.tsx
+++ b/src/context/storage-context/storage-context.tsx
@@ -45,6 +45,10 @@ export interface StorageContext {
         id: string;
         attributes: Partial<Diagram>;
     }) => Promise<void>;
+    modifyDiagram: (
+        diagramId: string,
+        modifyFn: (diagram: Diagram) => void
+    ) => Promise<void>;
     deleteDiagram: (id: string) => Promise<void>;
 
     // Table operations
@@ -149,6 +153,7 @@ export const storageInitialValue: StorageContext = {
     listDiagrams: emptyFn,
     getDiagram: emptyFn,
     updateDiagram: emptyFn,
+    modifyDiagram: emptyFn,
     deleteDiagram: emptyFn,
 
     addTable: emptyFn,

--- a/src/dialogs/import-database-dialog/import-database-dialog.tsx
+++ b/src/dialogs/import-database-dialog/import-database-dialog.tsx
@@ -289,19 +289,15 @@ export const ImportDatabaseDialog: React.FC<ImportDatabaseDialogProps> = ({
 
         if (!(await shouldRemove)) return;
 
-        await Promise.all([
-            removeTables(tableIdsToRemove, { updateHistory: false }),
-            removeRelationships(relationshipIdsToRemove, {
-                updateHistory: false,
-            }),
-        ]);
+        await removeTables(tableIdsToRemove, { updateHistory: false });
+        await removeRelationships(relationshipIdsToRemove, {
+            updateHistory: false,
+        });
 
-        await Promise.all([
-            addTables(diagram.tables ?? [], { updateHistory: false }),
-            addRelationships(diagram.relationships ?? [], {
-                updateHistory: false,
-            }),
-        ]);
+        await addTables(diagram.tables ?? [], { updateHistory: false });
+        await addRelationships(diagram.relationships ?? [], {
+            updateHistory: false,
+        });
 
         if (currentDatabaseType === DatabaseType.GENERIC) {
             await updateDatabaseType(databaseType);

--- a/src/dialogs/import-dbml-dialog/import-dbml-dialog.tsx
+++ b/src/dialogs/import-dbml-dialog/import-dbml-dialog.tsx
@@ -223,23 +223,19 @@ Ref: comments.user_id > users.id // Each comment is written by one user`;
                 })
                 .map((relationship) => relationship.id);
 
-            // Remove existing items
-            await Promise.all([
-                removeTables(tableIdsToRemove, { updateHistory: false }),
-                removeRelationships(relationshipIdsToRemove, {
-                    updateHistory: false,
-                }),
-            ]);
+            // Remove existing items sequentially to avoid race conditions
+            await removeTables(tableIdsToRemove, { updateHistory: false });
+            await removeRelationships(relationshipIdsToRemove, {
+                updateHistory: false,
+            });
 
-            // Add new items
-            await Promise.all([
-                addTables(importedDiagram.tables ?? [], {
-                    updateHistory: false,
-                }),
-                addRelationships(importedDiagram.relationships ?? [], {
-                    updateHistory: false,
-                }),
-            ]);
+            // Add new items sequentially so diagram writes don't clobber each other
+            await addTables(importedDiagram.tables ?? [], {
+                updateHistory: false,
+            });
+            await addRelationships(importedDiagram.relationships ?? [], {
+                updateHistory: false,
+            });
             setReorder(true);
             closeImportDBMLDialog();
         } catch (e) {


### PR DESCRIPTION
## Summary
- expose `modifyDiagram` helper in storage context
- atomically update diagrams when adding tables using `modifyDiagram`
- replace diagram and config file writes with atomic temp file swaps to avoid JSON corruption
- avoid races when importing DBML or database diagrams by updating tables and relationships sequentially
- preserve diagram identifiers during storage to persist relationships

## Testing
- `npm run lint`
- `npm test -- --run`


------
https://chatgpt.com/codex/tasks/task_e_68b0e9f2bfc4832c80147d7eae1e3ca8