### PR TITLE
Use storage JSON utility for diagram saves

### DIFF
--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -8,6 +8,7 @@ import type { Area } from '@/lib/domain/area';
 import type { DBCustomType } from '@/lib/domain/db-custom-type';
 import type { ChartDBConfig } from '@/lib/domain/config';
 import type { DiagramFilter } from '@/lib/domain/diagram-filter/diagram-filter';
+import { diagramToStorageJSON } from '@/lib/export-import-utils';
 
 const parseDiagram = (data: Record<string, unknown>): Diagram =>
     diagramSchema.parse({
@@ -15,9 +16,6 @@ const parseDiagram = (data: Record<string, unknown>): Diagram =>
         createdAt: new Date(data.createdAt as string),
         updatedAt: new Date(data.updatedAt as string),
     });
-
-const serializeDiagram = (diagram: Diagram): string =>
-    JSON.stringify(diagram, null, 2);
 
 const listDiagramsFromServer = async (): Promise<Diagram[]> => {
     const res = await fetch('/diagram');
@@ -38,7 +36,7 @@ const fetchDiagram = async (id: string): Promise<Diagram | undefined> => {
 };
 
 const saveDiagram = async (diagram: Diagram): Promise<void> => {
-    const json = serializeDiagram(diagram);
+    const json = diagramToStorageJSON(diagram);
     await fetch(`/diagram/${diagram.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },

--- a/src/lib/export-import-utils.ts
+++ b/src/lib/export-import-utils.ts
@@ -27,6 +27,24 @@ export const diagramToJSONOutput = (diagram: Diagram): string => {
     return JSON.stringify(clonedDiagram, null, 2);
 };
 
+export const diagramToStorageJSON = (diagram: Diagram): string => {
+    const storageDiagram: Diagram = {
+        ...diagram,
+        tables:
+            diagram.tables?.map((table) => ({
+                ...table,
+                x: table.x ?? 0,
+                y: table.y ?? 0,
+            })) ?? [],
+        relationships: diagram.relationships ?? [],
+        dependencies: diagram.dependencies ?? [],
+        areas: diagram.areas ?? [],
+        customTypes: diagram.customTypes ?? [],
+    };
+
+    return JSON.stringify(storageDiagram, null, 2);
+};
+
 export const diagramFromJSONInput = (json: string): Diagram => {
     const loadedDiagram = JSON.parse(json);
 


### PR DESCRIPTION
## Summary
- Add `diagramToStorageJSON` utility to persist diagrams without reassigning IDs and always include coordinates and optional arrays
- Update storage provider to use the new utility for all save operations

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b19aa31834832c85f5d6d1b45e861b