### PR TITLE
Fix diagram save to include full metadata

### DIFF
--- a/src/context/storage-context/storage-provider.tsx
+++ b/src/context/storage-context/storage-provider.tsx
@@ -8,7 +8,7 @@ import type { Area } from '@/lib/domain/area';
 import type { DBCustomType } from '@/lib/domain/db-custom-type';
 import type { ChartDBConfig } from '@/lib/domain/config';
 import type { DiagramFilter } from '@/lib/domain/diagram-filter/diagram-filter';
-import { diagramToJSONOutput } from '@/lib/export-import-utils';
+import { diagramToStorageJSON } from '@/lib/export-import-utils';
 
 const parseDiagram = (data: Record<string, unknown>): Diagram =>
     diagramSchema.parse({
@@ -39,7 +39,7 @@ const saveDiagram = async (diagram: Diagram): Promise<void> => {
     await fetch(`/diagram/${diagram.id}`, {
         method: 'PUT',
         headers: { 'Content-Type': 'application/json' },
-        body: diagramToJSONOutput(diagram),
+        body: JSON.stringify(diagramToStorageJSON(diagram), null, 2),
     });
 };
 

--- a/src/lib/data/data-types/data-types.ts
+++ b/src/lib/data/data-types/data-types.ts
@@ -12,6 +12,8 @@ import { oracleDataTypes } from './oracle-data-types';
 export interface DataType {
     id: string;
     name: string;
+    usageLevel?: 1 | 2;
+    fieldAttributes?: FieldAttributes;
 }
 
 export interface FieldAttributeRange {
@@ -20,7 +22,7 @@ export interface FieldAttributeRange {
     default: number;
 }
 
-interface FieldAttributes {
+export interface FieldAttributes {
     hasCharMaxLength?: boolean;
     hasCharMaxLengthOption?: boolean;
     precision?: FieldAttributeRange;
@@ -28,15 +30,36 @@ interface FieldAttributes {
     maxLength?: number;
 }
 
-export interface DataTypeData extends DataType {
-    usageLevel?: 1 | 2; // Level 1 is most common, Level 2 is second most common
-    fieldAttributes?: FieldAttributes;
-}
+export interface DataTypeData extends DataType {}
 
-export const dataTypeSchema: z.ZodType<DataType> = z.object({
-    id: z.string(),
-    name: z.string(),
-});
+export const dataTypeSchema: z.ZodType<DataType> = z
+    .object({
+        id: z.string(),
+        name: z.string(),
+        usageLevel: z.union([z.literal(1), z.literal(2)]).optional(),
+        fieldAttributes: z
+            .object({
+                hasCharMaxLength: z.boolean().optional(),
+                hasCharMaxLengthOption: z.boolean().optional(),
+                precision: z
+                    .object({
+                        max: z.number(),
+                        min: z.number(),
+                        default: z.number(),
+                    })
+                    .optional(),
+                scale: z
+                    .object({
+                        max: z.number(),
+                        min: z.number(),
+                        default: z.number(),
+                    })
+                    .optional(),
+                maxLength: z.number().optional(),
+            })
+            .optional(),
+    })
+    .passthrough();
 
 export const dataTypeMap: Record<DatabaseType, readonly DataTypeData[]> = {
     [DatabaseType.GENERIC]: genericDataTypes,


### PR DESCRIPTION
## Summary
- save diagrams using storage format so IDs and sections persist
- expand data type schema to keep usage levels and field attribute metadata

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b1f9385c6c832cb2dddf1f26eae983