### PR TITLE
feat: add start new diagram button

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,10 @@
 ## [1.15.1](https://github.com/chartdb/chartdb/compare/v1.15.0...v1.15.1) (2025-08-27)
 
 
+### Features
+
+* add "Start with a new diagram" option to open diagram dialog
+
 ### Bug Fixes
 
 * add actions menu to diagram list + add duplicate diagram ([#876](https://github.com/chartdb/chartdb/issues/876)) ([abd2a6c](https://github.com/chartdb/chartdb/commit/abd2a6ccbe1aa63db44ec28b3eff525cc5d3f8b0))

--- a/server.mjs
+++ b/server.mjs
@@ -13,8 +13,35 @@ app.use(express.json({ limit: '10mb' }));
 app.use(express.static(path.join(__dirname, 'dist')));
 
 const diagramFile = (id) => path.join(DATA_DIR, `${id}.json`);
+const isDiagramFile = (file) => /^[a-z0-9]{12}\.json$/.test(file);
 const sendIndexHtml = (res) => {
     res.sendFile(path.join(__dirname, 'dist', 'index.html'));
+};
+
+const normalizeDiagram = (diagram) => ({
+    ...diagram,
+    tables: (diagram.tables ?? []).map((table) => ({
+        ...table,
+        x: table.x ?? 0,
+        y: table.y ?? 0,
+    })),
+    relationships: diagram.relationships ?? [],
+    dependencies: diagram.dependencies ?? [],
+    areas: diagram.areas ?? [],
+    customTypes: diagram.customTypes ?? [],
+});
+
+const writeJsonAtomic = async (filePath, data) => {
+    const json = JSON.stringify(data, null, 2);
+    const tempPath = `${filePath}.tmp`;
+    const handle = await fs.open(tempPath, 'w');
+    try {
+        await handle.writeFile(json, 'utf-8');
+        await handle.sync();
+    } finally {
+        await handle.close();
+    }
+    await fs.rename(tempPath, filePath);
 };
 
 const wantsHtml = (req) => req.headers.accept?.includes('text/html');
@@ -27,14 +54,19 @@ app.get('/diagram', async (req, res) => {
         const files = await fs.readdir(DATA_DIR);
         const diagrams = [];
         for (const file of files) {
-            if (file.endsWith('.json') && file !== 'config.json') {
+            if (!isDiagramFile(file)) {
+                continue;
+            }
+            try {
                 const content = await fs.readFile(
                     path.join(DATA_DIR, file),
                     'utf-8'
                 );
-                const data = JSON.parse(content);
+                const data = normalizeDiagram(JSON.parse(content));
                 data.id = path.basename(file, '.json');
                 diagrams.push(data);
+            } catch {
+                // Ignore invalid JSON or files that can't be read
             }
         }
         res.json(diagrams);
@@ -49,7 +81,7 @@ app.get('/diagram/:id', async (req, res) => {
     }
     try {
         const content = await fs.readFile(diagramFile(req.params.id), 'utf-8');
-        const data = JSON.parse(content);
+        const data = normalizeDiagram(JSON.parse(content));
         data.id = req.params.id;
         res.json(data);
     } catch {
@@ -60,12 +92,8 @@ app.get('/diagram/:id', async (req, res) => {
 app.put('/diagram/:id', async (req, res) => {
     try {
         await fs.mkdir(DATA_DIR, { recursive: true });
-        const diagram = { ...req.body, id: req.params.id };
-        const json = JSON.stringify(diagram, null, 2);
-        const filePath = diagramFile(req.params.id);
-        const tempPath = `${filePath}.tmp`;
-        await fs.writeFile(tempPath, json, 'utf-8');
-        await fs.rename(tempPath, filePath);
+        const diagram = normalizeDiagram({ ...req.body, id: req.params.id });
+        await writeJsonAtomic(diagramFile(req.params.id), diagram);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save');
@@ -96,11 +124,8 @@ app.get('/config', async (_req, res) => {
 app.put('/config', async (req, res) => {
     try {
         await fs.mkdir(DATA_DIR, { recursive: true });
-        const json = JSON.stringify(req.body, null, 2);
         const filePath = path.join(DATA_DIR, 'config.json');
-        const tempPath = `${filePath}.tmp`;
-        await fs.writeFile(tempPath, json, 'utf-8');
-        await fs.rename(tempPath, filePath);
+        await writeJsonAtomic(filePath, req.body);
         res.status(204).end();
     } catch {
         res.status(500).send('Failed to save config');

--- a/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
+++ b/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
@@ -37,7 +37,7 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
     dialog,
     canClose = true,
 }) => {
-    const { closeOpenDiagramDialog } = useDialog();
+    const { closeOpenDiagramDialog, openCreateDiagramDialog } = useDialog();
     const { t } = useTranslation();
     const { updateConfig } = useConfig();
     const navigate = useNavigate();
@@ -117,6 +117,11 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
         },
         [openDiagram, closeOpenDiagramDialog]
     );
+
+    const startNewDiagram = useCallback(() => {
+        closeOpenDiagramDialog();
+        openCreateDiagramDialog();
+    }, [closeOpenDiagramDialog, openCreateDiagramDialog]);
 
     const onFocusHandler = useDebounce(
         (diagramId: string) => setSelectedDiagramId(diagramId),
@@ -254,15 +259,22 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
                     ) : (
                         <div />
                     )}
-                    <DialogClose asChild>
-                        <Button
-                            type="submit"
-                            disabled={!selectedDiagramId}
-                            onClick={() => openDiagram(selectedDiagramId ?? '')}
-                        >
-                            {t('open_diagram_dialog.open')}
+                    <div className="flex gap-2">
+                        <Button type="button" onClick={startNewDiagram}>
+                            {t('open_diagram_dialog.start_new')}
                         </Button>
-                    </DialogClose>
+                        <DialogClose asChild>
+                            <Button
+                                type="submit"
+                                disabled={!selectedDiagramId}
+                                onClick={() =>
+                                    openDiagram(selectedDiagramId ?? '')
+                                }
+                            >
+                                {t('open_diagram_dialog.open')}
+                            </Button>
+                        </DialogClose>
+                    </div>
                 </DialogFooter>
             </DialogContent>
         </Dialog>

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -322,6 +322,7 @@ export const ar: LanguageTranslation = {
                 tables_count: 'الجداول',
             },
             cancel: 'إلغاء',
+            start_new: 'Start with a new diagram',
             open: 'فتح',
 
             diagram_actions: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -324,6 +324,7 @@ export const bn: LanguageTranslation = {
                 tables_count: 'টেবিল',
             },
             cancel: 'বাতিল করুন',
+            start_new: 'Start with a new diagram',
             open: 'খুলুন',
 
             diagram_actions: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -327,6 +327,7 @@ export const de: LanguageTranslation = {
                 tables_count: 'Tabellen',
             },
             cancel: 'Abbrechen',
+            start_new: 'Start with a new diagram',
             open: 'Öffnen',
 
             diagram_actions: {

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -315,6 +315,7 @@ export const en = {
                 tables_count: 'Tables',
             },
             cancel: 'Cancel',
+            start_new: 'Start with a new diagram',
             open: 'Open',
 
             diagram_actions: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -325,6 +325,7 @@ export const es: LanguageTranslation = {
                 tables_count: 'Tablas',
             },
             cancel: 'Cancelar',
+            start_new: 'Start with a new diagram',
             open: 'Abrir',
 
             diagram_actions: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -322,6 +322,7 @@ export const fr: LanguageTranslation = {
                 tables_count: 'Tables',
             },
             cancel: 'Annuler',
+            start_new: 'Start with a new diagram',
             open: 'Ouvrir',
 
             diagram_actions: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -324,6 +324,7 @@ export const gu: LanguageTranslation = {
                 tables_count: 'ટેબલ્સ',
             },
             cancel: 'રદ કરો',
+            start_new: 'Start with a new diagram',
             open: 'ખોલો',
 
             diagram_actions: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -326,6 +326,7 @@ export const hi: LanguageTranslation = {
                 tables_count: 'तालिकाएँ',
             },
             cancel: 'रद्द करें',
+            start_new: 'Start with a new diagram',
             open: 'खोलें',
 
             diagram_actions: {

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -319,6 +319,7 @@ export const hr: LanguageTranslation = {
                 tables_count: 'Tablice',
             },
             cancel: 'Odustani',
+            start_new: 'Start with a new diagram',
             open: 'Otvori',
 
             diagram_actions: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -323,6 +323,7 @@ export const id_ID: LanguageTranslation = {
                 tables_count: 'Tabel',
             },
             cancel: 'Batal',
+            start_new: 'Start with a new diagram',
             open: 'Buka',
 
             diagram_actions: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -328,6 +328,7 @@ export const ja: LanguageTranslation = {
                 tables_count: 'テーブル数',
             },
             cancel: 'キャンセル',
+            start_new: 'Start with a new diagram',
             open: '開く',
 
             diagram_actions: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -323,6 +323,7 @@ export const ko_KR: LanguageTranslation = {
                 tables_count: '테이블 갯수',
             },
             cancel: '취소',
+            start_new: 'Start with a new diagram',
             open: '열기',
 
             diagram_actions: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -329,6 +329,7 @@ export const mr: LanguageTranslation = {
                 tables_count: 'टेबल्स',
             },
             cancel: 'रद्द करा',
+            start_new: 'Start with a new diagram',
             open: 'उघडा',
 
             diagram_actions: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -326,6 +326,7 @@ export const ne: LanguageTranslation = {
                 tables_count: 'तालिकाहरू',
             },
             cancel: 'रद्द गर्नुहोस्',
+            start_new: 'Start with a new diagram',
             open: 'खोल्नुहोस्',
 
             diagram_actions: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -325,6 +325,7 @@ export const pt_BR: LanguageTranslation = {
                 tables_count: 'Tabelas',
             },
             cancel: 'Cancelar',
+            start_new: 'Start with a new diagram',
             open: 'Abrir',
 
             diagram_actions: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -322,6 +322,7 @@ export const ru: LanguageTranslation = {
                 tables_count: 'Таблицы',
             },
             cancel: 'Отмена',
+            start_new: 'Start with a new diagram',
             open: 'Открыть',
 
             diagram_actions: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -326,6 +326,7 @@ export const te: LanguageTranslation = {
                 tables_count: 'పట్టికలు',
             },
             cancel: 'రద్దు',
+            start_new: 'Start with a new diagram',
             open: 'తెరవు',
 
             diagram_actions: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -321,6 +321,7 @@ export const tr: LanguageTranslation = {
                 tables_count: 'Tablolar',
             },
             cancel: 'İptal',
+            start_new: 'Start with a new diagram',
             open: 'Aç',
 
             diagram_actions: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -323,6 +323,7 @@ export const uk: LanguageTranslation = {
                 tables_count: 'Таблиці',
             },
             cancel: 'Скасувати',
+            start_new: 'Start with a new diagram',
             open: 'Відкрити',
 
             diagram_actions: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -323,6 +323,7 @@ export const vi: LanguageTranslation = {
                 tables_count: 'Số bảng',
             },
             cancel: 'Hủy',
+            start_new: 'Start with a new diagram',
             open: 'Mở',
 
             diagram_actions: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -320,6 +320,7 @@ export const zh_CN: LanguageTranslation = {
                 tables_count: '表数量',
             },
             cancel: '取消',
+            start_new: 'Start with a new diagram',
             open: '打开',
 
             diagram_actions: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -319,6 +319,7 @@ export const zh_TW: LanguageTranslation = {
                 tables_count: '表格數',
             },
             cancel: '取消',
+            start_new: 'Start with a new diagram',
             open: '開啟',
 
             diagram_actions: {


### PR DESCRIPTION
## Summary
- ensure saved diagrams always include table coordinates, custom types, areas, and dependencies by normalizing data on the server
- normalize diagrams when listing or fetching to fill in missing arrays and positions
- ignore stray JSON files when listing diagrams so empty data directories open the create dialog
- add "Start with a new diagram" option to the open diagram dialog to quickly create new diagrams

## Testing
- `npm test`
- `npx eslint src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx`
- `npx eslint src/i18n/locales/*.ts`


------
https://chatgpt.com/codex/tasks/task_e_68b21edbf75c832c86ed656423c9fde8