### PR TITLE
Ensure saving diagrams retains positions and areas

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -27,7 +27,13 @@ const normalizeDiagram = (diagram) => ({
     })),
     relationships: diagram.relationships ?? [],
     dependencies: diagram.dependencies ?? [],
-    areas: diagram.areas ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
     customTypes: diagram.customTypes ?? [],
 });
 

--- a/src/lib/export-import-utils.ts
+++ b/src/lib/export-import-utils.ts
@@ -29,15 +29,20 @@ export const diagramToJSONOutput = (diagram: Diagram): string => {
 
 export const diagramToStorageJSON = (diagram: Diagram): Diagram => ({
     ...diagram,
-    tables:
-        diagram.tables?.map((table) => ({
-            ...table,
-            x: table.x ?? 0,
-            y: table.y ?? 0,
-        })) ?? [],
+    tables: (diagram.tables ?? []).map((table) => ({
+        ...table,
+        x: table.x ?? 0,
+        y: table.y ?? 0,
+    })),
     relationships: diagram.relationships ?? [],
     dependencies: diagram.dependencies ?? [],
-    areas: diagram.areas ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
     customTypes: diagram.customTypes ?? [],
 });
 


### PR DESCRIPTION
## Summary
- include table and area position data when saving diagrams
- normalize diagrams server-side with complete area dimensions

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b2fb85c1a4832c8176e08410a47126