### PR TITLE
Ensure saving diagrams retains positions and areas

### DIFF
--- a/server.mjs
+++ b/server.mjs
@@ -27,7 +27,13 @@ const normalizeDiagram = (diagram) => ({
     })),
     relationships: diagram.relationships ?? [],
     dependencies: diagram.dependencies ?? [],
-    areas: diagram.areas ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
     customTypes: diagram.customTypes ?? [],
 });
 

--- a/src/context/keyboard-shortcuts-context/keyboard-shortcuts-provider.tsx
+++ b/src/context/keyboard-shortcuts-context/keyboard-shortcuts-provider.tsx
@@ -7,7 +7,7 @@ import {
 } from './keyboard-shortcuts';
 import { useHistory } from '@/hooks/use-history';
 import { useDialog } from '@/hooks/use-dialog';
-import { useChartDB } from '@/hooks/use-chartdb';
+import { useSaveDiagram } from '@/hooks/use-save-diagram';
 import { useLayout } from '@/hooks/use-layout';
 import { useReactFlow } from '@xyflow/react';
 
@@ -16,7 +16,7 @@ export const KeyboardShortcutsProvider: React.FC<React.PropsWithChildren> = ({
 }) => {
     const { redo, undo } = useHistory();
     const { openOpenDiagramDialog } = useDialog();
-    const { updateDiagramUpdatedAt } = useChartDB();
+    const { saveDiagram } = useSaveDiagram();
     const { toggleSidePanel } = useLayout();
     const { fitView } = useReactFlow();
 
@@ -48,11 +48,11 @@ export const KeyboardShortcutsProvider: React.FC<React.PropsWithChildren> = ({
     useHotkeys(
         keyboardShortcutsForOS[KeyboardShortcutAction.SAVE_DIAGRAM]
             .keyCombination,
-        updateDiagramUpdatedAt,
+        saveDiagram,
         {
             preventDefault: true,
         },
-        [updateDiagramUpdatedAt]
+        [saveDiagram]
     );
     useHotkeys(
         keyboardShortcutsForOS[KeyboardShortcutAction.TOGGLE_SIDE_PANEL]

--- a/src/hooks/use-save-diagram.tsx
+++ b/src/hooks/use-save-diagram.tsx
@@ -1,0 +1,26 @@
+import { useCallback, useState } from 'react';
+import { useChartDB } from '@/hooks/use-chartdb';
+import { waitFor } from '@/lib/utils';
+import { diagramToStorageJSON } from '@/lib/export-import-utils';
+import type { Diagram } from '@/lib/domain/diagram';
+
+export const useSaveDiagram = () => {
+    const [isSaving, setIsSaving] = useState(false);
+    const { currentDiagram, updateDiagramData } = useChartDB();
+
+    const saveDiagram = useCallback(async () => {
+        setIsSaving(true);
+        await waitFor(1000);
+        try {
+            const diagram: Diagram = diagramToStorageJSON({
+                ...currentDiagram,
+                updatedAt: new Date(),
+            });
+            await updateDiagramData(diagram, { forceUpdateStorage: true });
+        } finally {
+            setIsSaving(false);
+        }
+    }, [currentDiagram, updateDiagramData]);
+
+    return { saveDiagram, isSaving };
+};

--- a/src/lib/export-import-utils.ts
+++ b/src/lib/export-import-utils.ts
@@ -29,15 +29,20 @@ export const diagramToJSONOutput = (diagram: Diagram): string => {
 
 export const diagramToStorageJSON = (diagram: Diagram): Diagram => ({
     ...diagram,
-    tables:
-        diagram.tables?.map((table) => ({
-            ...table,
-            x: table.x ?? 0,
-            y: table.y ?? 0,
-        })) ?? [],
+    tables: (diagram.tables ?? []).map((table) => ({
+        ...table,
+        x: table.x ?? 0,
+        y: table.y ?? 0,
+    })),
     relationships: diagram.relationships ?? [],
     dependencies: diagram.dependencies ?? [],
-    areas: diagram.areas ?? [],
+    areas: (diagram.areas ?? []).map((area) => ({
+        ...area,
+        x: area.x ?? 0,
+        y: area.y ?? 0,
+        width: area.width ?? 0,
+        height: area.height ?? 0,
+    })),
     customTypes: diagram.customTypes ?? [],
 });
 

--- a/src/pages/editor-page/top-navbar/menu/menu.tsx
+++ b/src/pages/editor-page/top-navbar/menu/menu.tsx
@@ -13,6 +13,7 @@ import {
     MenubarTrigger,
 } from '@/components/menubar/menubar';
 import { useChartDB } from '@/hooks/use-chartdb';
+import { useSaveDiagram } from '@/hooks/use-save-diagram';
 import { useDialog } from '@/hooks/use-dialog';
 import { useExportImage } from '@/hooks/use-export-image';
 import { databaseTypeToLabelMap } from '@/lib/databases';
@@ -32,12 +33,8 @@ import { useAlert } from '@/context/alert-context/alert-context';
 export interface MenuProps {}
 
 export const Menu: React.FC<MenuProps> = () => {
-    const {
-        clearDiagramData,
-        deleteDiagram,
-        updateDiagramUpdatedAt,
-        databaseType,
-    } = useChartDB();
+    const { clearDiagramData, deleteDiagram, databaseType } = useChartDB();
+    const { saveDiagram } = useSaveDiagram();
     const {
         openCreateDiagramDialog,
         openOpenDiagramDialog,
@@ -166,7 +163,7 @@ export const Menu: React.FC<MenuProps> = () => {
                             }
                         </MenubarShortcut>
                     </MenubarItem>
-                    <MenubarItem onClick={updateDiagramUpdatedAt}>
+                    <MenubarItem onClick={saveDiagram}>
                         {t('menu.actions.save')}
                         <MenubarShortcut>
                             {


### PR DESCRIPTION
## Summary
- add a dedicated async save hook that persists the entire diagram state
- wire Save menu and keyboard shortcut to use the new hook

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68b2fb85c1a4832c8176e08410a47126