### PR TITLE
Ensure open diagram dialog closes after selection

### DIFF
--- a/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
+++ b/src/dialogs/open-diagram-dialog/open-diagram-dialog.tsx
@@ -267,9 +267,10 @@ export const OpenDiagramDialog: React.FC<OpenDiagramDialogProps> = ({
                             <Button
                                 type="submit"
                                 disabled={!selectedDiagramId}
-                                onClick={() =>
-                                    openDiagram(selectedDiagramId ?? '')
-                                }
+                                onClick={() => {
+                                    openDiagram(selectedDiagramId ?? '');
+                                    closeOpenDiagramDialog();
+                                }}
                             >
                                 {t('open_diagram_dialog.open')}
                             </Button>


### PR DESCRIPTION
## Summary
- close the open diagram dialog after opening a diagram to prevent it from lingering

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68b42731cef4832c809948497a96a27a