### PR TITLE
Support table-focused URLs

### DIFF
--- a/src/context/canvas-context/canvas-context.tsx
+++ b/src/context/canvas-context/canvas-context.tsx
@@ -2,14 +2,11 @@ import { createContext } from 'react';
 import { emptyFn } from '@/lib/utils';
 import type { Graph } from '@/lib/graph';
 import { createGraph } from '@/lib/graph';
+import type { FitViewOptions } from '@xyflow/react';
 
 export interface CanvasContext {
     reorderTables: (options?: { updateHistory?: boolean }) => void;
-    fitView: (options?: {
-        duration?: number;
-        padding?: number;
-        maxZoom?: number;
-    }) => void;
+    fitView: (options?: FitViewOptions) => void;
     setOverlapGraph: (graph: Graph<string>) => void;
     overlapGraph: Graph<string>;
     setShowFilter: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -28,6 +28,7 @@ import { FilterItemActions } from './filter-item-actions';
 import { databasesWithSchemas } from '@/lib/domain';
 import { getOperatingSystem } from '@/lib/utils';
 import { useLocalConfig } from '@/hooks/use-local-config';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -52,6 +53,9 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const [groupingMode, setGroupingMode] = useState<GroupingMode>('schema');
     const searchInputRef = useRef<HTMLInputElement>(null);
     const { showDBViews } = useLocalConfig();
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     // Extract only the properties needed for tree data
     const relevantTableData = useMemo<RelevantTableData[]>(
@@ -188,8 +192,12 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
                     ],
                 });
             }, 100);
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${tableId}${search}`);
+            }
         },
-        [fitView, setNodes]
+        [fitView, setNodes, navigate, diagramId, search]
     );
 
     // Handle node click

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -28,6 +28,7 @@ import {
     useKeyPress,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { useParams } from 'react-router-dom';
 import equal from 'fast-deep-equal';
 import type { TableNodeType } from './table-node/table-node';
 import { TableNode } from './table-node/table-node';
@@ -247,7 +248,14 @@ export const Canvas: React.FC<CanvasProps> = ({
         showFilter,
         setShowFilter,
     } = useCanvas();
-    const { filter, loading: filterLoading } = useDiagramFilter();
+    const {
+        filter,
+        loading: filterLoading,
+        setTableIdsFilterEmpty,
+        addTablesToFilter,
+        clearTableIdsFilter,
+    } = useDiagramFilter();
+    const { tableId } = useParams<{ diagramId: string; tableId?: string }>();
 
     const [isInitialLoadingNodes, setIsInitialLoadingNodes] = useState(true);
 
@@ -292,7 +300,7 @@ export const Canvas: React.FC<CanvasProps> = ({
     ]);
 
     useEffect(() => {
-        if (!isInitialLoadingNodes) {
+        if (!isInitialLoadingNodes && !tableId) {
             debounce(() => {
                 fitView({
                     duration: 200,
@@ -301,7 +309,48 @@ export const Canvas: React.FC<CanvasProps> = ({
                 });
             }, 500)();
         }
-    }, [isInitialLoadingNodes, fitView]);
+    }, [isInitialLoadingNodes, fitView, tableId]);
+
+    useEffect(() => {
+        if (!tableId) {
+            setNodes((nodes) =>
+                nodes.map((node) => ({ ...node, selected: false }))
+            );
+            clearTableIdsFilter();
+            return;
+        }
+
+        if (clean) {
+            setTableIdsFilterEmpty();
+            addTablesToFilter({ tableIds: [tableId] });
+        } else {
+            clearTableIdsFilter();
+        }
+
+        setTimeout(() => {
+            setNodes((nodes) =>
+                nodes.map((node) =>
+                    node.id === tableId
+                        ? { ...node, selected: true }
+                        : { ...node, selected: false }
+                )
+            );
+            fitView({
+                duration: 500,
+                maxZoom: 1,
+                minZoom: 1,
+                nodes: [{ id: tableId }],
+            });
+        }, 100);
+    }, [
+        tableId,
+        clean,
+        setTableIdsFilterEmpty,
+        addTablesToFilter,
+        clearTableIdsFilter,
+        setNodes,
+        fitView,
+    ]);
 
     useEffect(() => {
         const targetIndexes: Record<string, number> = relationships.reduce(
@@ -520,15 +569,17 @@ export const Canvas: React.FC<CanvasProps> = ({
                     ),
                 });
                 setOverlapGraph(overlappingTablesInDiagram);
-                fitView({
-                    duration: 500,
-                    padding: 0.1,
-                    maxZoom: 0.8,
-                });
+                if (!tableId) {
+                    fitView({
+                        duration: 500,
+                        padding: 0.1,
+                        maxZoom: 0.8,
+                    });
+                }
             }, 500)();
             prevFilter.current = filter;
         }
-    }, [filter, fitView, tables, setOverlapGraph, databaseType]);
+    }, [filter, fitView, tables, setOverlapGraph, databaseType, tableId]);
 
     useEffect(() => {
         const checkParentAreas = debounce(() => {

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/tooltip/tooltip';
 import { cloneTable } from '@/lib/clone';
 import type { DBSchema } from '@/lib/domain';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
 
@@ -68,6 +69,9 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const { isMd: isDesktop } = useBreakpoint('md');
     const inputRef = React.useRef<HTMLInputElement>(null);
     const { listeners } = useSortable({ id: table.id });
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -122,8 +126,21 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
             if (!isDesktop) {
                 hideSidePanel();
             }
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${table.id}${search}`);
+            }
         },
-        [fitView, table.id, setNodes, hideSidePanel, isDesktop]
+        [
+            fitView,
+            table.id,
+            setNodes,
+            hideSidePanel,
+            isDesktop,
+            navigate,
+            diagramId,
+            search,
+        ]
     );
 
     const deleteTableHandler = useCallback(() => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,18 +6,20 @@ import type { TemplatesPageLoaderData } from './pages/templates-page/templates-p
 import { getTemplatesAndAllTags } from './templates-data/template-utils';
 
 const routes: RouteObject[] = [
-    ...['', 'diagrams/:diagramId'].map((path) => ({
-        path,
-        async lazy() {
-            const { EditorPage } = await import(
-                './pages/editor-page/editor-page'
-            );
+    ...['', 'diagrams/:diagramId', 'diagrams/:diagramId/:tableId'].map(
+        (path) => ({
+            path,
+            async lazy() {
+                const { EditorPage } = await import(
+                    './pages/editor-page/editor-page'
+                );
 
-            return {
-                element: <EditorPage />,
-            };
-        },
-    })),
+                return {
+                    element: <EditorPage />,
+                };
+            },
+        })
+    ),
     {
         path: 'examples',
         async lazy() {


### PR DESCRIPTION
## Summary
- Add routing for table-specific URLs
- Update focus actions to push selected table ID to browser path
- Auto-focus tables from URL and hide others in clean mode
- Allow canvas context `fitView` to accept full React Flow options, enabling `minZoom`
- Skip global diagram fit when a specific table is focused to prevent zoom-out

## Testing
- `npm test`
- `npm run lint`
- `npm run build` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b755ff5ec0832ca2f1e075d13220d2