### PR TITLE
Support table-focused URLs

### DIFF
--- a/src/context/canvas-context/canvas-context.tsx
+++ b/src/context/canvas-context/canvas-context.tsx
@@ -2,14 +2,11 @@ import { createContext } from 'react';
 import { emptyFn } from '@/lib/utils';
 import type { Graph } from '@/lib/graph';
 import { createGraph } from '@/lib/graph';
+import type { FitViewOptions } from '@xyflow/react';
 
 export interface CanvasContext {
     reorderTables: (options?: { updateHistory?: boolean }) => void;
-    fitView: (options?: {
-        duration?: number;
-        padding?: number;
-        maxZoom?: number;
-    }) => void;
+    fitView: (options?: FitViewOptions) => void;
     setOverlapGraph: (graph: Graph<string>) => void;
     overlapGraph: Graph<string>;
     setShowFilter: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -28,6 +28,7 @@ import { FilterItemActions } from './filter-item-actions';
 import { databasesWithSchemas } from '@/lib/domain';
 import { getOperatingSystem } from '@/lib/utils';
 import { useLocalConfig } from '@/hooks/use-local-config';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -35,7 +36,7 @@ export interface CanvasFilterProps {
 
 export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const { t } = useTranslation();
-    const { tables, databaseType, areas } = useChartDB();
+    const { tables, databaseType, areas, updateTable } = useChartDB();
     const {
         filter,
         toggleSchemaFilter,
@@ -52,6 +53,9 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const [groupingMode, setGroupingMode] = useState<GroupingMode>('schema');
     const searchInputRef = useRef<HTMLInputElement>(null);
     const { showDBViews } = useLocalConfig();
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     // Extract only the properties needed for tree data
     const relevantTableData = useMemo<RelevantTableData[]>(
@@ -175,6 +179,8 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
                 )
             );
 
+            updateTable(tableId, { expanded: true });
+
             // Focus on the table
             setTimeout(() => {
                 fitView({
@@ -188,8 +194,12 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
                     ],
                 });
             }, 100);
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${tableId}${search}`);
+            }
         },
-        [fitView, setNodes]
+        [fitView, setNodes, navigate, diagramId, search, updateTable]
     );
 
     // Handle node click

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -28,6 +28,7 @@ import {
     useKeyPress,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { useParams } from 'react-router-dom';
 import equal from 'fast-deep-equal';
 import type { TableNodeType } from './table-node/table-node';
 import { TableNode } from './table-node/table-node';
@@ -93,7 +94,11 @@ import { ShowAllButton } from './show-all-button';
 import { useIsLostInCanvas } from './hooks/use-is-lost-in-canvas';
 import type { DiagramFilter } from '@/lib/domain/diagram-filter/diagram-filter';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
-import { filterTable } from '@/lib/domain/diagram-filter/filter';
+import {
+    filterTable,
+    filterRelationship,
+    filterDependency,
+} from '@/lib/domain/diagram-filter/filter';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 
 const HIGHLIGHTED_EDGE_Z_INDEX = 1;
@@ -231,6 +236,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         updateArea,
         highlightedCustomType,
         highlightCustomTypeId,
+        updateTable,
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
@@ -248,6 +254,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         setShowFilter,
     } = useCanvas();
     const { filter, loading: filterLoading } = useDiagramFilter();
+    const { tableId } = useParams<{ diagramId: string; tableId?: string }>();
 
     const [isInitialLoadingNodes, setIsInitialLoadingNodes] = useState(true);
 
@@ -292,7 +299,7 @@ export const Canvas: React.FC<CanvasProps> = ({
     ]);
 
     useEffect(() => {
-        if (!isInitialLoadingNodes) {
+        if (!isInitialLoadingNodes && !tableId) {
             debounce(() => {
                 fitView({
                     duration: 200,
@@ -301,29 +308,100 @@ export const Canvas: React.FC<CanvasProps> = ({
                 });
             }, 500)();
         }
-    }, [isInitialLoadingNodes, fitView]);
+    }, [isInitialLoadingNodes, fitView, tableId]);
 
     useEffect(() => {
-        const targetIndexes: Record<string, number> = relationships.reduce(
-            (acc, relationship) => {
-                acc[
-                    `${relationship.targetTableId}${relationship.targetFieldId}`
-                ] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
+        if (!tableId) {
+            setNodes((nodes) =>
+                nodes.map((node) => ({ ...node, selected: false }))
+            );
+            return;
+        }
+
+        updateTable(tableId, { expanded: true });
+
+        setTimeout(() => {
+            setNodes((nodes) =>
+                nodes.map((node) =>
+                    node.id === tableId
+                        ? { ...node, selected: true }
+                        : { ...node, selected: false }
+                )
+            );
+            fitView({
+                duration: 500,
+                maxZoom: 1,
+                minZoom: 1,
+                nodes: [{ id: tableId }],
+            });
+        }, 100);
+    }, [tableId, setNodes, fitView, updateTable]);
+
+    useEffect(() => {
+        if (clean && tableId) {
+            setEdges([]);
+            return;
+        }
+
+        const defaultSchema = defaultSchemas[databaseType];
+
+        const visibleRelationships = relationships.filter((relationship) =>
+            filterRelationship({
+                tableA: {
+                    id: relationship.sourceTableId,
+                    schema: tables.find(
+                        (t) => t.id === relationship.sourceTableId
+                    )?.schema,
+                },
+                tableB: {
+                    id: relationship.targetTableId,
+                    schema: tables.find(
+                        (t) => t.id === relationship.targetTableId
+                    )?.schema,
+                },
+                filter,
+                options: { defaultSchema },
+            })
         );
 
-        const targetDepIndexes: Record<string, number> = dependencies.reduce(
-            (acc, dep) => {
-                acc[dep.tableId] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
+        const targetIndexes: Record<string, number> =
+            visibleRelationships.reduce(
+                (acc, relationship) => {
+                    acc[
+                        `${relationship.targetTableId}${relationship.targetFieldId}`
+                    ] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
+
+        const visibleDependencies = dependencies.filter((dep) =>
+            filterDependency({
+                tableA: {
+                    id: dep.tableId,
+                    schema: tables.find((t) => t.id === dep.tableId)?.schema,
+                },
+                tableB: {
+                    id: dep.dependentTableId,
+                    schema: tables.find((t) => t.id === dep.dependentTableId)
+                        ?.schema,
+                },
+                filter,
+                options: { defaultSchema },
+            })
         );
+
+        const targetDepIndexes: Record<string, number> =
+            visibleDependencies.reduce(
+                (acc, dep) => {
+                    acc[dep.tableId] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
 
         setEdges([
-            ...relationships.map(
+            ...visibleRelationships.map(
                 (relationship): RelationshipEdgeType => ({
                     id: relationship.id,
                     source: relationship.sourceTableId,
@@ -334,7 +412,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                     data: { relationship },
                 })
             ),
-            ...dependencies.map(
+            ...visibleDependencies.map(
                 (dep): DependencyEdgeType => ({
                     id: dep.id,
                     source: dep.dependentTableId,
@@ -347,7 +425,17 @@ export const Canvas: React.FC<CanvasProps> = ({
                 })
             ),
         ]);
-    }, [relationships, dependencies, setEdges, showDBViews]);
+    }, [
+        relationships,
+        dependencies,
+        setEdges,
+        showDBViews,
+        filter,
+        tables,
+        databaseType,
+        clean,
+        tableId,
+    ]);
 
     useEffect(() => {
         const selectedNodesIds = nodes
@@ -440,8 +528,14 @@ export const Canvas: React.FC<CanvasProps> = ({
 
     useEffect(() => {
         setNodes((prevNodes) => {
+            const visibleTables =
+                clean && tableId
+                    ? tables.filter((table) => table.id === tableId)
+                    : tables;
+            const visibleAreas = clean && tableId ? [] : areas;
+
             const newNodes = [
-                ...tables.map((table) => {
+                ...visibleTables.map((table) => {
                     const isOverlapping =
                         (overlapGraph.graph.get(table.id) ?? []).length > 0;
                     const node = tableToTableNode(table, {
@@ -470,7 +564,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                         },
                     };
                 }),
-                ...areas.map((area) =>
+                ...visibleAreas.map((area) =>
                     areaToAreaNode(area, {
                         tables,
                         filter,
@@ -499,6 +593,8 @@ export const Canvas: React.FC<CanvasProps> = ({
         highlightedCustomType,
         filterLoading,
         showDBViews,
+        clean,
+        tableId,
     ]);
 
     const prevFilter = useRef<DiagramFilter | undefined>(undefined);
@@ -520,15 +616,17 @@ export const Canvas: React.FC<CanvasProps> = ({
                     ),
                 });
                 setOverlapGraph(overlappingTablesInDiagram);
-                fitView({
-                    duration: 500,
-                    padding: 0.1,
-                    maxZoom: 0.8,
-                });
+                if (!tableId) {
+                    fitView({
+                        duration: 500,
+                        padding: 0.1,
+                        maxZoom: 0.8,
+                    });
+                }
             }, 500)();
             prevFilter.current = filter;
         }
-    }, [filter, fitView, tables, setOverlapGraph, databaseType]);
+    }, [filter, fitView, tables, setOverlapGraph, databaseType, tableId]);
 
     useEffect(() => {
         const checkParentAreas = debounce(() => {

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -74,6 +74,9 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         const edges = useStore((store) => store.edges) as EdgeType[];
         const { openTableFromSidebar, selectSidebarSection } = useLayout();
         const [expanded, setExpanded] = useState(table.expanded ?? false);
+        useEffect(() => {
+            setExpanded(table.expanded ?? false);
+        }, [table.expanded]);
         const { t } = useTranslation();
         const [editMode, setEditMode] = useState(false);
         const [tableName, setTableName] = useState(table.name);

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -38,6 +38,7 @@ import {
 } from '@/components/tooltip/tooltip';
 import { cloneTable } from '@/lib/clone';
 import type { DBSchema } from '@/lib/domain';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
 
@@ -68,6 +69,9 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const { isMd: isDesktop } = useBreakpoint('md');
     const inputRef = React.useRef<HTMLInputElement>(null);
     const { listeners } = useSortable({ id: table.id });
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -108,6 +112,8 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
                           }
                 )
             );
+
+            updateTable(table.id, { expanded: true });
             fitView({
                 duration: 500,
                 maxZoom: 1,
@@ -122,8 +128,22 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
             if (!isDesktop) {
                 hideSidePanel();
             }
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${table.id}${search}`);
+            }
         },
-        [fitView, table.id, setNodes, hideSidePanel, isDesktop]
+        [
+            fitView,
+            table.id,
+            setNodes,
+            hideSidePanel,
+            isDesktop,
+            navigate,
+            diagramId,
+            search,
+            updateTable,
+        ]
     );
 
     const deleteTableHandler = useCallback(() => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,18 +6,20 @@ import type { TemplatesPageLoaderData } from './pages/templates-page/templates-p
 import { getTemplatesAndAllTags } from './templates-data/template-utils';
 
 const routes: RouteObject[] = [
-    ...['', 'diagrams/:diagramId'].map((path) => ({
-        path,
-        async lazy() {
-            const { EditorPage } = await import(
-                './pages/editor-page/editor-page'
-            );
+    ...['', 'diagrams/:diagramId', 'diagrams/:diagramId/:tableId'].map(
+        (path) => ({
+            path,
+            async lazy() {
+                const { EditorPage } = await import(
+                    './pages/editor-page/editor-page'
+                );
 
-            return {
-                element: <EditorPage />,
-            };
-        },
-    })),
+                return {
+                    element: <EditorPage />,
+                };
+            },
+        })
+    ),
     {
         path: 'examples',
         async lazy() {


### PR DESCRIPTION
## Summary
- Add routing for table-specific URLs
- Update focus actions to push selected table ID to browser path
- Auto-focus tables from URL and hide others in clean mode
- Allow canvas context `fitView` to accept full React Flow options, enabling `minZoom`
- Skip global diagram fit when a specific table is focused to prevent zoom-out
- Hide other tables and edges when a table is focused in clean mode
- Auto-expand tables whenever they are focused from the UI or URL
- Clear edges only when `clean=true`, preventing flicker
- Stop mutating diagram filter when focusing tables so it isn't saved and switching focus works

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build` *(fails: JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b755ff5ec0832ca2f1e075d13220d2