### PR TITLE
Support table-focused URLs

### DIFF
--- a/src/context/canvas-context/canvas-context.tsx
+++ b/src/context/canvas-context/canvas-context.tsx
@@ -2,14 +2,11 @@ import { createContext } from 'react';
 import { emptyFn } from '@/lib/utils';
 import type { Graph } from '@/lib/graph';
 import { createGraph } from '@/lib/graph';
+import type { FitViewOptions } from '@xyflow/react';
 
 export interface CanvasContext {
     reorderTables: (options?: { updateHistory?: boolean }) => void;
-    fitView: (options?: {
-        duration?: number;
-        padding?: number;
-        maxZoom?: number;
-    }) => void;
+    fitView: (options?: FitViewOptions) => void;
     setOverlapGraph: (graph: Graph<string>) => void;
     overlapGraph: Graph<string>;
     setShowFilter: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -10,7 +10,6 @@ import { useChartDB } from '@/hooks/use-chartdb';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/button/button';
 import { Input } from '@/components/input/input';
-import { useReactFlow } from '@xyflow/react';
 import { TreeView } from '@/components/tree-view/tree-view';
 import type { TreeNode } from '@/components/tree-view/tree';
 import { ScrollArea } from '@/components/scroll-area/scroll-area';
@@ -28,6 +27,7 @@ import { FilterItemActions } from './filter-item-actions';
 import { databasesWithSchemas } from '@/lib/domain';
 import { getOperatingSystem } from '@/lib/utils';
 import { useLocalConfig } from '@/hooks/use-local-config';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -35,6 +35,7 @@ export interface CanvasFilterProps {
 
 export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const { t } = useTranslation();
+    // Pull only required values to avoid unused variables
     const { tables, databaseType, areas } = useChartDB();
     const {
         filter,
@@ -45,13 +46,15 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
         addTablesToFilter,
         removeTablesFromFilter,
     } = useDiagramFilter();
-    const { fitView, setNodes } = useReactFlow();
     const [searchQuery, setSearchQuery] = useState('');
     const [expanded, setExpanded] = useState<Record<string, boolean>>({});
     const [isFilterVisible, setIsFilterVisible] = useState(false);
     const [groupingMode, setGroupingMode] = useState<GroupingMode>('schema');
     const searchInputRef = useRef<HTMLInputElement>(null);
     const { showDBViews } = useLocalConfig();
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     // Extract only the properties needed for tree data
     const relevantTableData = useMemo<RelevantTableData[]>(
@@ -159,37 +162,11 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
 
     const focusOnTable = useCallback(
         (tableId: string) => {
-            // Make sure the table is visible
-            setNodes((nodes) =>
-                nodes.map((node) =>
-                    node.id === tableId
-                        ? {
-                              ...node,
-                              hidden: false,
-                              selected: true,
-                          }
-                        : {
-                              ...node,
-                              selected: false,
-                          }
-                )
-            );
-
-            // Focus on the table
-            setTimeout(() => {
-                fitView({
-                    duration: 500,
-                    maxZoom: 1,
-                    minZoom: 1,
-                    nodes: [
-                        {
-                            id: tableId,
-                        },
-                    ],
-                });
-            }, 100);
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${tableId}${search}`);
+            }
         },
-        [fitView, setNodes]
+        [navigate, diagramId, search]
     );
 
     // Handle node click

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -74,6 +74,9 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         const edges = useStore((store) => store.edges) as EdgeType[];
         const { openTableFromSidebar, selectSidebarSection } = useLayout();
         const [expanded, setExpanded] = useState(table.expanded ?? false);
+        useEffect(() => {
+            setExpanded(table.expanded ?? false);
+        }, [table.expanded]);
         const { t } = useTranslation();
         const [editMode, setEditMode] = useState(false);
         const [tableName, setTableName] = useState(table.name);

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -26,7 +26,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/dropdown-menu/dropdown-menu';
-import { useReactFlow } from '@xyflow/react';
 import { useLayout } from '@/hooks/use-layout';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +37,7 @@ import {
 } from '@/components/tooltip/tooltip';
 import { cloneTable } from '@/lib/clone';
 import type { DBSchema } from '@/lib/domain';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
 
@@ -61,13 +61,15 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const { schemasDisplayed } = useDiagramFilter();
     const { openTableSchemaDialog } = useDialog();
     const { t } = useTranslation();
-    const { fitView, setNodes } = useReactFlow();
     const { hideSidePanel } = useLayout();
     const [editMode, setEditMode] = React.useState(false);
     const [tableName, setTableName] = React.useState(table.name);
     const { isMd: isDesktop } = useBreakpoint('md');
     const inputRef = React.useRef<HTMLInputElement>(null);
     const { listeners } = useSortable({ id: table.id });
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -95,35 +97,16 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const focusOnTable = useCallback(
         (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
             event.stopPropagation();
-            setNodes((nodes) =>
-                nodes.map((node) =>
-                    node.id == table.id
-                        ? {
-                              ...node,
-                              selected: true,
-                          }
-                        : {
-                              ...node,
-                              selected: false,
-                          }
-                )
-            );
-            fitView({
-                duration: 500,
-                maxZoom: 1,
-                minZoom: 1,
-                nodes: [
-                    {
-                        id: table.id,
-                    },
-                ],
-            });
 
             if (!isDesktop) {
                 hideSidePanel();
             }
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${table.id}${search}`);
+            }
         },
-        [fitView, table.id, setNodes, hideSidePanel, isDesktop]
+        [table.id, hideSidePanel, isDesktop, navigate, diagramId, search]
     );
 
     const deleteTableHandler = useCallback(() => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,18 +6,20 @@ import type { TemplatesPageLoaderData } from './pages/templates-page/templates-p
 import { getTemplatesAndAllTags } from './templates-data/template-utils';
 
 const routes: RouteObject[] = [
-    ...['', 'diagrams/:diagramId'].map((path) => ({
-        path,
-        async lazy() {
-            const { EditorPage } = await import(
-                './pages/editor-page/editor-page'
-            );
+    ...['', 'diagrams/:diagramId', 'diagrams/:diagramId/:tableId'].map(
+        (path) => ({
+            path,
+            async lazy() {
+                const { EditorPage } = await import(
+                    './pages/editor-page/editor-page'
+                );
 
-            return {
-                element: <EditorPage />,
-            };
-        },
-    })),
+                return {
+                    element: <EditorPage />,
+                };
+            },
+        })
+    ),
     {
         path: 'examples',
         async lazy() {


### PR DESCRIPTION
## Summary
- Add routing for table-specific URLs
- Update focus actions to push selected table ID to browser path
- Auto-focus tables from URL and hide others in clean mode
- Allow canvas context `fitView` to accept full React Flow options, enabling `minZoom`
- Skip global diagram fit when a specific table is focused to prevent zoom-out
- Hide other tables and edges when a table is focused in clean mode
- Auto-expand tables whenever they are focused from the UI or URL
- Clear edges only when `clean=true`, preventing flicker
- Stop mutating diagram filter when focusing tables so it isn't saved and switching focus works
- Filter initial nodes and remove delayed animations so focused tables center instantly without lingering selections
- Click on empty canvas to exit table focus and return to the diagram
- Focus buttons now rely solely on navigation to avoid duplicate fit logic
- Broaden `fitView` typing to accept full React Flow `FitViewOptions`
- Remove unused table updater to satisfy lint

## Testing
- `npm run lint`
- `npm test -- --run`
- `npm run build` *(fails: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b755ff5ec0832ca2f1e075d13220d2