### PR TITLE
Support table-focused URLs

### DIFF
--- a/src/context/canvas-context/canvas-context.tsx
+++ b/src/context/canvas-context/canvas-context.tsx
@@ -2,14 +2,11 @@ import { createContext } from 'react';
 import { emptyFn } from '@/lib/utils';
 import type { Graph } from '@/lib/graph';
 import { createGraph } from '@/lib/graph';
+import type { FitViewOptions } from '@xyflow/react';
 
 export interface CanvasContext {
     reorderTables: (options?: { updateHistory?: boolean }) => void;
-    fitView: (options?: {
-        duration?: number;
-        padding?: number;
-        maxZoom?: number;
-    }) => void;
+    fitView: (options?: FitViewOptions) => void;
     setOverlapGraph: (graph: Graph<string>) => void;
     overlapGraph: Graph<string>;
     setShowFilter: React.Dispatch<React.SetStateAction<boolean>>;

--- a/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
+++ b/src/pages/editor-page/canvas/canvas-filter/canvas-filter.tsx
@@ -10,7 +10,6 @@ import { useChartDB } from '@/hooks/use-chartdb';
 import { useTranslation } from 'react-i18next';
 import { Button } from '@/components/button/button';
 import { Input } from '@/components/input/input';
-import { useReactFlow } from '@xyflow/react';
 import { TreeView } from '@/components/tree-view/tree-view';
 import type { TreeNode } from '@/components/tree-view/tree';
 import { ScrollArea } from '@/components/scroll-area/scroll-area';
@@ -28,6 +27,7 @@ import { FilterItemActions } from './filter-item-actions';
 import { databasesWithSchemas } from '@/lib/domain';
 import { getOperatingSystem } from '@/lib/utils';
 import { useLocalConfig } from '@/hooks/use-local-config';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 
 export interface CanvasFilterProps {
     onClose: () => void;
@@ -35,6 +35,7 @@ export interface CanvasFilterProps {
 
 export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
     const { t } = useTranslation();
+    // Pull only required values to avoid unused variables
     const { tables, databaseType, areas } = useChartDB();
     const {
         filter,
@@ -45,13 +46,15 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
         addTablesToFilter,
         removeTablesFromFilter,
     } = useDiagramFilter();
-    const { fitView, setNodes } = useReactFlow();
     const [searchQuery, setSearchQuery] = useState('');
     const [expanded, setExpanded] = useState<Record<string, boolean>>({});
     const [isFilterVisible, setIsFilterVisible] = useState(false);
     const [groupingMode, setGroupingMode] = useState<GroupingMode>('schema');
     const searchInputRef = useRef<HTMLInputElement>(null);
     const { showDBViews } = useLocalConfig();
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     // Extract only the properties needed for tree data
     const relevantTableData = useMemo<RelevantTableData[]>(
@@ -159,37 +162,11 @@ export const CanvasFilter: React.FC<CanvasFilterProps> = ({ onClose }) => {
 
     const focusOnTable = useCallback(
         (tableId: string) => {
-            // Make sure the table is visible
-            setNodes((nodes) =>
-                nodes.map((node) =>
-                    node.id === tableId
-                        ? {
-                              ...node,
-                              hidden: false,
-                              selected: true,
-                          }
-                        : {
-                              ...node,
-                              selected: false,
-                          }
-                )
-            );
-
-            // Focus on the table
-            setTimeout(() => {
-                fitView({
-                    duration: 500,
-                    maxZoom: 1,
-                    minZoom: 1,
-                    nodes: [
-                        {
-                            id: tableId,
-                        },
-                    ],
-                });
-            }, 100);
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${tableId}${search}`);
+            }
         },
-        [fitView, setNodes]
+        [navigate, diagramId, search]
     );
 
     // Handle node click

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -28,6 +28,7 @@ import {
     useKeyPress,
 } from '@xyflow/react';
 import '@xyflow/react/dist/style.css';
+import { useParams, useNavigate, useLocation } from 'react-router-dom';
 import equal from 'fast-deep-equal';
 import type { TableNodeType } from './table-node/table-node';
 import { TableNode } from './table-node/table-node';
@@ -93,7 +94,11 @@ import { ShowAllButton } from './show-all-button';
 import { useIsLostInCanvas } from './hooks/use-is-lost-in-canvas';
 import type { DiagramFilter } from '@/lib/domain/diagram-filter/diagram-filter';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
-import { filterTable } from '@/lib/domain/diagram-filter/filter';
+import {
+    filterTable,
+    filterRelationship,
+    filterDependency,
+} from '@/lib/domain/diagram-filter/filter';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 
 const HIGHLIGHTED_EDGE_Z_INDEX = 1;
@@ -205,7 +210,7 @@ export const Canvas: React.FC<CanvasProps> = ({
     initialTables,
     clean = false,
 }) => {
-    const { getEdge, getInternalNode, getNode } = useReactFlow();
+    const { getEdge, getInternalNode, getNode, setCenter } = useReactFlow();
     const [selectedTableIds, setSelectedTableIds] = useState<string[]>([]);
     const [selectedRelationshipIds, setSelectedRelationshipIds] = useState<
         string[]
@@ -231,6 +236,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         updateArea,
         highlightedCustomType,
         highlightCustomTypeId,
+        updateTable,
     } = useChartDB();
     const { showSidePanel } = useLayout();
     const { effectiveTheme } = useTheme();
@@ -248,11 +254,19 @@ export const Canvas: React.FC<CanvasProps> = ({
         setShowFilter,
     } = useCanvas();
     const { filter, loading: filterLoading } = useDiagramFilter();
+    const { diagramId, tableId } = useParams<{
+        diagramId: string;
+        tableId?: string;
+    }>();
+    const navigate = useNavigate();
+    const { search } = useLocation();
 
-    const [isInitialLoadingNodes, setIsInitialLoadingNodes] = useState(true);
-
+    const initialNodeTables =
+        clean && tableId
+            ? initialTables.filter((table) => table.id === tableId)
+            : initialTables;
     const [nodes, setNodes, onNodesChange] = useNodesState<NodeType>(
-        initialTables.map((table) =>
+        initialNodeTables.map((table) =>
             tableToTableNode(table, {
                 filter,
                 databaseType,
@@ -267,32 +281,39 @@ export const Canvas: React.FC<CanvasProps> = ({
     const [snapToGridEnabled, setSnapToGridEnabled] = useState(false);
 
     useEffect(() => {
-        setIsInitialLoadingNodes(true);
-    }, [initialTables]);
-
-    useEffect(() => {
-        const initialNodes = initialTables.map((table) =>
-            tableToTableNode(table, {
-                filter,
-                databaseType,
-                filterLoading,
-                showDBViews,
-            })
-        );
-        if (equal(initialNodes, nodes)) {
-            setIsInitialLoadingNodes(false);
+        const nextTables =
+            clean && tableId
+                ? tables.filter((table) => table.id === tableId)
+                : tables;
+        const nextNodes = nextTables.map((table) => {
+            const existing = nodes.find((n) => n.id === table.id);
+            return {
+                ...tableToTableNode(table, {
+                    filter,
+                    databaseType,
+                    filterLoading,
+                    showDBViews,
+                }),
+                selected: existing?.selected ?? false,
+            };
+        });
+        if (!equal(nextNodes, nodes)) {
+            setNodes(nextNodes);
         }
     }, [
-        initialTables,
-        nodes,
+        tables,
+        clean,
+        tableId,
         filter,
         databaseType,
         filterLoading,
         showDBViews,
+        setNodes,
+        nodes,
     ]);
 
     useEffect(() => {
-        if (!isInitialLoadingNodes) {
+        if (!tableId) {
             debounce(() => {
                 fitView({
                     duration: 200,
@@ -301,29 +322,113 @@ export const Canvas: React.FC<CanvasProps> = ({
                 });
             }, 500)();
         }
-    }, [isInitialLoadingNodes, fitView]);
+    }, [tableId, nodes, fitView]);
 
     useEffect(() => {
-        const targetIndexes: Record<string, number> = relationships.reduce(
-            (acc, relationship) => {
-                acc[
-                    `${relationship.targetTableId}${relationship.targetFieldId}`
-                ] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
+        if (!tableId) {
+            setNodes((nodes) =>
+                nodes.map((node) => ({ ...node, selected: false }))
+            );
+            return;
+        }
+
+        updateTable(tableId, { expanded: true });
+
+        setNodes((nodes) =>
+            nodes.map((node) =>
+                node.id === tableId
+                    ? { ...node, selected: true }
+                    : { ...node, selected: false }
+            )
         );
 
-        const targetDepIndexes: Record<string, number> = dependencies.reduce(
-            (acc, dep) => {
-                acc[dep.tableId] = 0;
-                return acc;
-            },
-            {} as Record<string, number>
+        setTimeout(() => {
+            const node = getNode(tableId);
+            if (!node) {
+                return;
+            }
+            if (clean) {
+                fitView({
+                    duration: 0,
+                    maxZoom: 1,
+                    minZoom: 1,
+                    nodes: [{ id: tableId }],
+                });
+            } else {
+                setCenter(
+                    node.position.x + (node.width ?? 0) / 2,
+                    node.position.y + (node.height ?? 0) / 2,
+                    { zoom: 1 }
+                );
+            }
+        });
+    }, [tableId, clean, setNodes, fitView, updateTable, getNode, setCenter]);
+
+    useEffect(() => {
+        if (clean && tableId) {
+            setEdges([]);
+            return;
+        }
+
+        const defaultSchema = defaultSchemas[databaseType];
+
+        const visibleRelationships = relationships.filter((relationship) =>
+            filterRelationship({
+                tableA: {
+                    id: relationship.sourceTableId,
+                    schema: tables.find(
+                        (t) => t.id === relationship.sourceTableId
+                    )?.schema,
+                },
+                tableB: {
+                    id: relationship.targetTableId,
+                    schema: tables.find(
+                        (t) => t.id === relationship.targetTableId
+                    )?.schema,
+                },
+                filter,
+                options: { defaultSchema },
+            })
         );
+
+        const targetIndexes: Record<string, number> =
+            visibleRelationships.reduce(
+                (acc, relationship) => {
+                    acc[
+                        `${relationship.targetTableId}${relationship.targetFieldId}`
+                    ] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
+
+        const visibleDependencies = dependencies.filter((dep) =>
+            filterDependency({
+                tableA: {
+                    id: dep.tableId,
+                    schema: tables.find((t) => t.id === dep.tableId)?.schema,
+                },
+                tableB: {
+                    id: dep.dependentTableId,
+                    schema: tables.find((t) => t.id === dep.dependentTableId)
+                        ?.schema,
+                },
+                filter,
+                options: { defaultSchema },
+            })
+        );
+
+        const targetDepIndexes: Record<string, number> =
+            visibleDependencies.reduce(
+                (acc, dep) => {
+                    acc[dep.tableId] = 0;
+                    return acc;
+                },
+                {} as Record<string, number>
+            );
 
         setEdges([
-            ...relationships.map(
+            ...visibleRelationships.map(
                 (relationship): RelationshipEdgeType => ({
                     id: relationship.id,
                     source: relationship.sourceTableId,
@@ -334,7 +439,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                     data: { relationship },
                 })
             ),
-            ...dependencies.map(
+            ...visibleDependencies.map(
                 (dep): DependencyEdgeType => ({
                     id: dep.id,
                     source: dep.dependentTableId,
@@ -347,7 +452,17 @@ export const Canvas: React.FC<CanvasProps> = ({
                 })
             ),
         ]);
-    }, [relationships, dependencies, setEdges, showDBViews]);
+    }, [
+        relationships,
+        dependencies,
+        setEdges,
+        showDBViews,
+        filter,
+        tables,
+        databaseType,
+        clean,
+        tableId,
+    ]);
 
     useEffect(() => {
         const selectedNodesIds = nodes
@@ -440,8 +555,14 @@ export const Canvas: React.FC<CanvasProps> = ({
 
     useEffect(() => {
         setNodes((prevNodes) => {
+            const visibleTables =
+                clean && tableId
+                    ? tables.filter((table) => table.id === tableId)
+                    : tables;
+            const visibleAreas = clean && tableId ? [] : areas;
+
             const newNodes = [
-                ...tables.map((table) => {
+                ...visibleTables.map((table) => {
                     const isOverlapping =
                         (overlapGraph.graph.get(table.id) ?? []).length > 0;
                     const node = tableToTableNode(table, {
@@ -470,7 +591,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                         },
                     };
                 }),
-                ...areas.map((area) =>
+                ...visibleAreas.map((area) =>
                     areaToAreaNode(area, {
                         tables,
                         filter,
@@ -499,6 +620,8 @@ export const Canvas: React.FC<CanvasProps> = ({
         highlightedCustomType,
         filterLoading,
         showDBViews,
+        clean,
+        tableId,
     ]);
 
     const prevFilter = useRef<DiagramFilter | undefined>(undefined);
@@ -520,15 +643,17 @@ export const Canvas: React.FC<CanvasProps> = ({
                     ),
                 });
                 setOverlapGraph(overlappingTablesInDiagram);
-                fitView({
-                    duration: 500,
-                    padding: 0.1,
-                    maxZoom: 0.8,
-                });
+                if (!tableId) {
+                    fitView({
+                        duration: 500,
+                        padding: 0.1,
+                        maxZoom: 0.8,
+                    });
+                }
             }, 500)();
             prevFilter.current = filter;
         }
-    }, [filter, fitView, tables, setOverlapGraph, databaseType]);
+    }, [filter, fitView, tables, setOverlapGraph, databaseType, tableId]);
 
     useEffect(() => {
         const checkParentAreas = debounce(() => {
@@ -1227,6 +1352,12 @@ export const Canvas: React.FC<CanvasProps> = ({
         []
     );
 
+    const handlePaneClick = useCallback(() => {
+        if (!clean && tableId && diagramId) {
+            navigate(`/diagrams/${diagramId}${search}`);
+        }
+    }, [clean, tableId, diagramId, navigate, search]);
+
     return (
         <CanvasContextMenu>
             <div className="relative flex size-full" id="canvas">
@@ -1241,6 +1372,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                     maxZoom={5}
                     minZoom={0.1}
                     onConnect={onConnectHandler}
+                    onPaneClick={handlePaneClick}
                     proOptions={{
                         hideAttribution: true,
                     }}

--- a/src/pages/editor-page/canvas/table-node/table-node.tsx
+++ b/src/pages/editor-page/canvas/table-node/table-node.tsx
@@ -74,6 +74,9 @@ export const TableNode: React.FC<NodeProps<TableNodeType>> = React.memo(
         const edges = useStore((store) => store.edges) as EdgeType[];
         const { openTableFromSidebar, selectSidebarSection } = useLayout();
         const [expanded, setExpanded] = useState(table.expanded ?? false);
+        useEffect(() => {
+            setExpanded(table.expanded ?? false);
+        }, [table.expanded]);
         const { t } = useTranslation();
         const [editMode, setEditMode] = useState(false);
         const [tableName, setTableName] = useState(table.name);

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -26,7 +26,6 @@ import {
     DropdownMenuSeparator,
     DropdownMenuTrigger,
 } from '@/components/dropdown-menu/dropdown-menu';
-import { useReactFlow } from '@xyflow/react';
 import { useLayout } from '@/hooks/use-layout';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { useTranslation } from 'react-i18next';
@@ -38,6 +37,7 @@ import {
 } from '@/components/tooltip/tooltip';
 import { cloneTable } from '@/lib/clone';
 import type { DBSchema } from '@/lib/domain';
+import { useNavigate, useLocation, useParams } from 'react-router-dom';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
 
@@ -61,13 +61,15 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const { schemasDisplayed } = useDiagramFilter();
     const { openTableSchemaDialog } = useDialog();
     const { t } = useTranslation();
-    const { fitView, setNodes } = useReactFlow();
     const { hideSidePanel } = useLayout();
     const [editMode, setEditMode] = React.useState(false);
     const [tableName, setTableName] = React.useState(table.name);
     const { isMd: isDesktop } = useBreakpoint('md');
     const inputRef = React.useRef<HTMLInputElement>(null);
     const { listeners } = useSortable({ id: table.id });
+    const navigate = useNavigate();
+    const { search } = useLocation();
+    const { diagramId } = useParams<{ diagramId: string }>();
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -95,35 +97,16 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const focusOnTable = useCallback(
         (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
             event.stopPropagation();
-            setNodes((nodes) =>
-                nodes.map((node) =>
-                    node.id == table.id
-                        ? {
-                              ...node,
-                              selected: true,
-                          }
-                        : {
-                              ...node,
-                              selected: false,
-                          }
-                )
-            );
-            fitView({
-                duration: 500,
-                maxZoom: 1,
-                minZoom: 1,
-                nodes: [
-                    {
-                        id: table.id,
-                    },
-                ],
-            });
 
             if (!isDesktop) {
                 hideSidePanel();
             }
+
+            if (diagramId) {
+                navigate(`/diagrams/${diagramId}/${table.id}${search}`);
+            }
         },
-        [fitView, table.id, setNodes, hideSidePanel, isDesktop]
+        [table.id, hideSidePanel, isDesktop, navigate, diagramId, search]
     );
 
     const deleteTableHandler = useCallback(() => {

--- a/src/router.tsx
+++ b/src/router.tsx
@@ -6,18 +6,20 @@ import type { TemplatesPageLoaderData } from './pages/templates-page/templates-p
 import { getTemplatesAndAllTags } from './templates-data/template-utils';
 
 const routes: RouteObject[] = [
-    ...['', 'diagrams/:diagramId'].map((path) => ({
-        path,
-        async lazy() {
-            const { EditorPage } = await import(
-                './pages/editor-page/editor-page'
-            );
+    ...['', 'diagrams/:diagramId', 'diagrams/:diagramId/:tableId'].map(
+        (path) => ({
+            path,
+            async lazy() {
+                const { EditorPage } = await import(
+                    './pages/editor-page/editor-page'
+                );
 
-            return {
-                element: <EditorPage />,
-            };
-        },
-    })),
+                return {
+                    element: <EditorPage />,
+                };
+            },
+        })
+    ),
     {
         path: 'examples',
         async lazy() {


### PR DESCRIPTION
## Summary
- Ensure canvas nodes refresh when focus or clean mode changes so switching tables clears the old focus
- Restore diagram-wide fit on load and when exiting table focus
- Center focused tables without locking panning in normal mode and restrict zoom only in clean view
- Clicking the canvas background now exits table focus

## Testing
- `npm run lint`
- `npm test -- --run`
- `NODE_OPTIONS=--max_old_space_size=4096 npm run build`


------
https://chatgpt.com/codex/tasks/task_e_68b755ff5ec0832ca2f1e075d13220d2