### PR TITLE
fix: include setEdges and guard tableId in useEffect

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -349,7 +349,11 @@ export const Canvas: React.FC<CanvasProps> = ({
     }, [tableId, setNodes, fitView, updateTable]);
 
     useEffect(() => {
-        if (clean && tableId) {
+        if (!tableId) {
+            return;
+        }
+
+        if (clean) {
             setEdges([]);
             return;
         }
@@ -374,7 +378,16 @@ export const Canvas: React.FC<CanvasProps> = ({
                 );
             }
         });
-    }, [tableId, clean, setNodes, fitView, updateTable, getNode, setCenter]);
+    }, [
+        tableId,
+        clean,
+        setNodes,
+        fitView,
+        updateTable,
+        getNode,
+        setCenter,
+        setEdges,
+    ]);
 
     useEffect(() => {
         if (clean && tableId) {


### PR DESCRIPTION
## Summary
- include `setEdges` in `useEffect` dependencies
- guard `tableId` before centering or clearing edges to avoid undefined usage

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*


------
https://chatgpt.com/codex/tasks/task_e_68b8b93f46d0832cb2a57a4d5a293d85