### PR TITLE
fix: restore table focusing behavior

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -355,6 +355,9 @@ export const Canvas: React.FC<CanvasProps> = ({
         }
 
         setTimeout(() => {
+            if (!tableId) {
+                return;
+            }
             const node = getNode(tableId);
             if (!node) {
                 return;
@@ -374,7 +377,16 @@ export const Canvas: React.FC<CanvasProps> = ({
                 );
             }
         });
-    }, [tableId, clean, setNodes, fitView, updateTable, getNode, setCenter]);
+    }, [
+        tableId,
+        clean,
+        setNodes,
+        fitView,
+        updateTable,
+        getNode,
+        setCenter,
+        setEdges,
+    ]);
 
     useEffect(() => {
         if (clean && tableId) {


### PR DESCRIPTION
## Summary
- restore table focusing logic by clearing edges only when a focused table is shown in clean mode
- guard centered view updates until the focused table exists to prevent focus glitches

## Testing
- `npm run lint`
- `npm test`
- `npm run build` *(fails: FATAL ERROR: Reached heap limit Allocation failed - JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68b8b93f46d0832cb2a57a4d5a293d85