### PR TITLE
feat: share individual tables in clean view

### DIFF
--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -16,15 +16,20 @@ import { TopNavbar } from './top-navbar/top-navbar';
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
 
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        const tables = tableId
+            ? (initialDiagram?.tables?.filter((t) => t.id === tableId) ?? [])
+            : (initialDiagram?.tables ?? []);
+        return <Canvas initialTables={tables} clean focusTableId={tableId} />;
     }
 
     return (

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -18,14 +18,19 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        const tables = tableId
+            ? (initialDiagram?.tables?.filter((t) => t.id === tableId) ?? [])
+            : (initialDiagram?.tables ?? []);
+        return <Canvas initialTables={tables} clean focusTableId={tableId} />;
     }
     return (
         <>

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -41,10 +41,12 @@ export const EditorMobileLayoutLazy = React.lazy(
 
 interface EditorPageComponentProps {
     clean?: boolean;
+    tableId?: string | null;
 }
 
 const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
     clean = false,
+    tableId,
 }) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
@@ -107,11 +109,13 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     )}
                 </Suspense>
@@ -124,6 +128,7 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
 export const EditorPage: React.FC = () => {
     const [searchParams] = useSearchParams();
     const clean = searchParams.get('clean') === 'true';
+    const tableId = clean ? searchParams.get('table') : null;
 
     return (
         <LocalConfigProvider>
@@ -143,10 +148,10 @@ export const EditorPage: React.FC = () => {
                                                                 <AlertProvider>
                                                                     <DialogProvider>
                                                                         <KeyboardShortcutsProvider>
+                                                                            {/* prettier-ignore */}
                                                                             <EditorPageComponent
-                                                                                clean={
-                                                                                    clean
-                                                                                }
+                                                                                clean={clean}
+                                                                                tableId={tableId}
                                                                             />
                                                                         </KeyboardShortcutsProvider>
                                                                     </DialogProvider>


### PR DESCRIPTION
## Summary
- add share button per table to copy clean link with table id
- support clean mode with optional table parameter to show only that table
- disable interactions and animations when focusing a single table

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baacddde10832cae08576e7d09dc50