### PR TITLE
feat: share individual tables in clean view

### DIFF
--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -16,15 +16,23 @@ import { TopNavbar } from './top-navbar/top-navbar';
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
 
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                focusTableId={tableId}
+            />
+        );
     }
 
     return (

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -18,14 +18,22 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                focusTableId={tableId}
+            />
+        );
     }
     return (
         <>

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -41,17 +41,19 @@ export const EditorMobileLayoutLazy = React.lazy(
 
 interface EditorPageComponentProps {
     clean?: boolean;
+    tableId?: string | null;
 }
 
 const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
     clean = false,
+    tableId,
 }) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
     const { isMd: isDesktop } = useBreakpoint('md');
     const { starUsDialogLastOpen, setStarUsDialogLastOpen, githubRepoOpened } =
         useLocalConfig();
-    const { initialDiagram } = useDiagramLoader();
+    const { initialDiagram } = useDiagramLoader({ clean, tableId });
 
     useEffect(() => {
         if (clean || HIDE_CHARTDB_CLOUD) {
@@ -107,11 +109,13 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     )}
                 </Suspense>
@@ -124,6 +128,7 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
 export const EditorPage: React.FC = () => {
     const [searchParams] = useSearchParams();
     const clean = searchParams.get('clean') === 'true';
+    const tableId = clean ? searchParams.get('table') : null;
 
     return (
         <LocalConfigProvider>
@@ -143,10 +148,10 @@ export const EditorPage: React.FC = () => {
                                                                 <AlertProvider>
                                                                     <DialogProvider>
                                                                         <KeyboardShortcutsProvider>
+                                                                            {/* prettier-ignore */}
                                                                             <EditorPageComponent
-                                                                                clean={
-                                                                                    clean
-                                                                                }
+                                                                                clean={clean}
+                                                                                tableId={tableId}
                                                                             />
                                                                         </KeyboardShortcutsProvider>
                                                                     </DialogProvider>


### PR DESCRIPTION
## Summary
- add share button per table to copy clean link with table id
- support clean mode with optional table parameter to show only that table
- disable interactions and animations when focusing a single table
- hide non-focused tables and skip auto zoom when loading a shared table link
- ensure shared links load only the requested table and center without animation

## Testing
- `npm run lint`
- `npx vitest run` *(fails: Error parsing CREATE TABLE statement in MySQL importer test)*

------
https://chatgpt.com/codex/tasks/task_e_68baacddde10832cae08576e7d09dc50