### PR TITLE
feat: share individual tables in clean view

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -199,13 +199,20 @@ const areaToAreaNode = (
 export interface CanvasProps {
     initialTables: DBTable[];
     clean?: boolean;
+    focusTableId?: string;
 }
 
 export const Canvas: React.FC<CanvasProps> = ({
     initialTables,
     clean = false,
+    focusTableId,
 }) => {
-    const { getEdge, getInternalNode, getNode } = useReactFlow();
+    const {
+        getEdge,
+        getInternalNode,
+        getNode,
+        fitView: reactFlowFitView,
+    } = useReactFlow();
     const [selectedTableIds, setSelectedTableIds] = useState<string[]>([]);
     const [selectedRelationshipIds, setSelectedRelationshipIds] = useState<
         string[]
@@ -292,18 +299,39 @@ export const Canvas: React.FC<CanvasProps> = ({
     ]);
 
     useEffect(() => {
-        if (!isInitialLoadingNodes) {
-            debounce(() => {
-                fitView({
-                    duration: 200,
-                    padding: 0.1,
-                    maxZoom: 0.8,
-                });
-            }, 500)();
+        if (!isInitialLoadingNodes && !focusTableId) {
+            const action = () =>
+                fitView({ duration: 200, padding: 0.1, maxZoom: 0.8 });
+            debounce(action, 500)();
         }
-    }, [isInitialLoadingNodes, fitView]);
+    }, [isInitialLoadingNodes, fitView, focusTableId]);
 
     useEffect(() => {
+        if (!focusTableId) {
+            return;
+        }
+        let frame = 0;
+        const center = () => {
+            const node = getInternalNode(focusTableId);
+            if (!node?.width || !node?.height) {
+                frame = requestAnimationFrame(center);
+                return;
+            }
+            reactFlowFitView({
+                nodes: [{ id: focusTableId }],
+                duration: 0,
+                padding: 0.1,
+            });
+        };
+        frame = requestAnimationFrame(center);
+        return () => cancelAnimationFrame(frame);
+    }, [focusTableId, getInternalNode, reactFlowFitView]);
+
+    useEffect(() => {
+        if (focusTableId) {
+            setEdges([]);
+            return;
+        }
         const targetIndexes: Record<string, number> = relationships.reduce(
             (acc, relationship) => {
                 acc[
@@ -347,7 +375,7 @@ export const Canvas: React.FC<CanvasProps> = ({
                 })
             ),
         ]);
-    }, [relationships, dependencies, setEdges, showDBViews]);
+    }, [relationships, dependencies, setEdges, showDBViews, focusTableId]);
 
     useEffect(() => {
         const selectedNodesIds = nodes
@@ -440,8 +468,11 @@ export const Canvas: React.FC<CanvasProps> = ({
 
     useEffect(() => {
         setNodes((prevNodes) => {
+            const visibleTables = focusTableId
+                ? tables.filter((table) => table.id === focusTableId)
+                : tables;
             const newNodes = [
-                ...tables.map((table) => {
+                ...visibleTables.map((table) => {
                     const isOverlapping =
                         (overlapGraph.graph.get(table.id) ?? []).length > 0;
                     const node = tableToTableNode(table, {
@@ -470,14 +501,16 @@ export const Canvas: React.FC<CanvasProps> = ({
                         },
                     };
                 }),
-                ...areas.map((area) =>
-                    areaToAreaNode(area, {
-                        tables,
-                        filter,
-                        databaseType,
-                        filterLoading,
-                    })
-                ),
+                ...(focusTableId
+                    ? []
+                    : areas.map((area) =>
+                          areaToAreaNode(area, {
+                              tables,
+                              filter,
+                              databaseType,
+                              filterLoading,
+                          })
+                      )),
             ];
 
             // Check if nodes actually changed
@@ -499,10 +532,15 @@ export const Canvas: React.FC<CanvasProps> = ({
         highlightedCustomType,
         filterLoading,
         showDBViews,
+        focusTableId,
     ]);
 
     const prevFilter = useRef<DiagramFilter | undefined>(undefined);
     useEffect(() => {
+        if (focusTableId) {
+            prevFilter.current = filter;
+            return;
+        }
         if (!equal(filter, prevFilter.current)) {
             debounce(() => {
                 const overlappingTablesInDiagram = findOverlappingTables({
@@ -528,9 +566,12 @@ export const Canvas: React.FC<CanvasProps> = ({
             }, 500)();
             prevFilter.current = filter;
         }
-    }, [filter, fitView, tables, setOverlapGraph, databaseType]);
+    }, [filter, fitView, tables, setOverlapGraph, databaseType, focusTableId]);
 
     useEffect(() => {
+        if (focusTableId) {
+            return;
+        }
         const checkParentAreas = debounce(() => {
             const visibleTables = nodes
                 .filter((node) => node.type === 'table' && !node.hidden)
@@ -583,7 +624,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         }, 300);
 
         checkParentAreas();
-    }, [nodes, updateTablesState]);
+    }, [nodes, updateTablesState, focusTableId]);
 
     const onConnectHandler = useCallback(
         async (params: AddEdgeParams) => {
@@ -1233,7 +1274,10 @@ export const Canvas: React.FC<CanvasProps> = ({
                 <ReactFlow
                     onlyRenderVisibleElements
                     colorMode={effectiveTheme}
-                    className="canvas-cursor-default nodes-animated"
+                    className={cn(
+                        'canvas-cursor-default',
+                        focusTableId ? '' : 'nodes-animated'
+                    )}
                     nodes={nodes}
                     edges={edges}
                     onNodesChange={onNodesChangeHandler}
@@ -1251,7 +1295,14 @@ export const Canvas: React.FC<CanvasProps> = ({
                         animated: false,
                         type: 'relationship-edge',
                     }}
-                    panOnScroll={scrollAction === 'pan'}
+                    panOnScroll={!focusTableId && scrollAction === 'pan'}
+                    panOnDrag={!focusTableId}
+                    zoomOnScroll={!focusTableId}
+                    zoomOnPinch={!focusTableId}
+                    zoomOnDoubleClick={!focusTableId}
+                    nodesDraggable={!focusTableId && !readonly}
+                    nodesConnectable={!focusTableId && !readonly}
+                    elementsSelectable={!focusTableId}
                     snapToGrid={shiftPressed || snapToGridEnabled}
                     snapGrid={[20, 20]}
                 >

--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -16,15 +16,23 @@ import { TopNavbar } from './top-navbar/top-navbar';
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
 
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                focusTableId={tableId}
+            />
+        );
     }
 
     return (

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -18,14 +18,22 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                focusTableId={tableId}
+            />
+        );
     }
     return (
         <>

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -41,17 +41,19 @@ export const EditorMobileLayoutLazy = React.lazy(
 
 interface EditorPageComponentProps {
     clean?: boolean;
+    tableId?: string | null;
 }
 
 const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
     clean = false,
+    tableId,
 }) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
     const { isMd: isDesktop } = useBreakpoint('md');
     const { starUsDialogLastOpen, setStarUsDialogLastOpen, githubRepoOpened } =
         useLocalConfig();
-    const { initialDiagram } = useDiagramLoader();
+    const { initialDiagram } = useDiagramLoader({ clean, tableId });
 
     useEffect(() => {
         if (clean || HIDE_CHARTDB_CLOUD) {
@@ -107,11 +109,13 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId ?? undefined}
                         />
                     )}
                 </Suspense>
@@ -124,6 +128,7 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
 export const EditorPage: React.FC = () => {
     const [searchParams] = useSearchParams();
     const clean = searchParams.get('clean') === 'true';
+    const tableId = clean ? searchParams.get('table') : null;
 
     return (
         <LocalConfigProvider>
@@ -143,10 +148,10 @@ export const EditorPage: React.FC = () => {
                                                                 <AlertProvider>
                                                                     <DialogProvider>
                                                                         <KeyboardShortcutsProvider>
+                                                                            {/* prettier-ignore */}
                                                                             <EditorPageComponent
-                                                                                clean={
-                                                                                    clean
-                                                                                }
+                                                                                clean={clean}
+                                                                                tableId={tableId}
                                                                             />
                                                                         </KeyboardShortcutsProvider>
                                                                     </DialogProvider>


### PR DESCRIPTION
## Summary
- add share button per table to copy clean link with table id
- support clean mode with optional table parameter to show only that table
- disable interactions and animations when focusing a single table
- hide non-focused tables and skip auto zoom when loading a shared table link
- ensure shared links load only the requested table and center without animation
- center shared table in view and fit zoom to the node
- wait for canvas and nodes to mount before centering single-table view

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68baacddde10832cae08576e7d09dc50