### PR TITLE
fix: center canvas on selected table in clean mode

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -52,7 +52,6 @@ import { useLayout } from '@/hooks/use-layout';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { Badge } from '@/components/badge/badge';
 import { useTheme } from '@/hooks/use-theme';
-import { useFocusOn } from '@/hooks/use-focus-on';
 import { useTranslation } from 'react-i18next';
 import type { DBTable } from '@/lib/domain/db-table';
 import { MIN_TABLE_SIZE } from '@/lib/domain/db-table';
@@ -252,7 +251,6 @@ export const Canvas: React.FC<CanvasProps> = ({
         setShowFilter,
     } = useCanvas();
     const { filter, loading: filterLoading } = useDiagramFilter();
-    const { focusOnTable } = useFocusOn();
 
     const [isInitialLoadingNodes, setIsInitialLoadingNodes] = useState(true);
 
@@ -315,11 +313,19 @@ export const Canvas: React.FC<CanvasProps> = ({
                 frame = requestAnimationFrame(center);
                 return;
             }
-            focusOnTable(focusTableId, { select: false, duration: 0 });
+            fitView({
+                duration: 0,
+                nodes: [
+                    {
+                        id: focusTableId,
+                    },
+                ],
+                padding: 0.1,
+            });
         };
         frame = requestAnimationFrame(center);
         return () => cancelAnimationFrame(frame);
-    }, [focusTableId, getInternalNode, focusOnTable]);
+    }, [focusTableId, getInternalNode, fitView]);
 
     useEffect(() => {
         if (focusTableId) {


### PR DESCRIPTION
## Summary
- ensure canvas centers and fits selected table when opened in clean mode with table id

## Testing
- `npm run lint`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68bd2ddd27fc832c8f612baacf1d48d9