### PR TITLE
fix: center view on table in clean mode

### DIFF
--- a/src/context/canvas-context/canvas-context.tsx
+++ b/src/context/canvas-context/canvas-context.tsx
@@ -9,6 +9,7 @@ export interface CanvasContext {
         duration?: number;
         padding?: number;
         maxZoom?: number;
+        nodes?: Array<{ id: string }>;
     }) => void;
     setOverlapGraph: (graph: Graph<string>) => void;
     overlapGraph: Graph<string>;

--- a/src/hooks/use-focus-on.ts
+++ b/src/hooks/use-focus-on.ts
@@ -6,6 +6,7 @@ import { useBreakpoint } from '@/hooks/use-breakpoint';
 interface FocusOptions {
     select?: boolean;
     duration?: number;
+    fit?: boolean;
 }
 
 export const useFocusOn = () => {
@@ -53,7 +54,7 @@ export const useFocusOn = () => {
 
     const focusOnTable = useCallback(
         (tableId: string, options: FocusOptions = {}) => {
-            const { select = true, duration = 500 } = options;
+            const { select = true, duration = 500, fit = false } = options;
 
             if (select) {
                 setNodes((nodes) =>
@@ -74,7 +75,7 @@ export const useFocusOn = () => {
             fitView({
                 duration,
                 maxZoom: 1,
-                minZoom: 1,
+                ...(fit ? { padding: 0.1 } : { minZoom: 1 }),
                 nodes: [
                     {
                         id: tableId,

--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -315,7 +315,11 @@ export const Canvas: React.FC<CanvasProps> = ({
                 frame = requestAnimationFrame(center);
                 return;
             }
-            focusOnTable(focusTableId, { select: false, duration: 0 });
+            focusOnTable(focusTableId, {
+                select: false,
+                duration: 0,
+                fit: true,
+            });
         };
         frame = requestAnimationFrame(center);
         return () => cancelAnimationFrame(frame);


### PR DESCRIPTION
## Summary
- allow focusing hook to fit view around a table via optional `fit` flag
- center and fit canvas on selected table when clean mode passes table id
- update canvas context type so `fitView` accepts node targets

## Testing
- `npm run lint`
- `npm test`
- `NODE_OPTIONS=--max_old_space_size=4096 npx tsc -p tsconfig.json --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_68bd2ddd27fc832c8f612baacf1d48d9