### PR TITLE
fix: center view on table in clean mode

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -52,7 +52,6 @@ import { useLayout } from '@/hooks/use-layout';
 import { useBreakpoint } from '@/hooks/use-breakpoint';
 import { Badge } from '@/components/badge/badge';
 import { useTheme } from '@/hooks/use-theme';
-import { useFocusOn } from '@/hooks/use-focus-on';
 import { useTranslation } from 'react-i18next';
 import type { DBTable } from '@/lib/domain/db-table';
 import { MIN_TABLE_SIZE } from '@/lib/domain/db-table';
@@ -208,8 +207,7 @@ export const Canvas: React.FC<CanvasProps> = ({
     clean = false,
     focusTableId,
 }) => {
-    // FitView from useReactFlow is intentionally omitted to avoid an unused variable.
-    const { getEdge, getInternalNode, getNode } = useReactFlow();
+    const { getEdge, getInternalNode, getNode, fitView } = useReactFlow();
     const [selectedTableIds, setSelectedTableIds] = useState<string[]>([]);
     const [selectedRelationshipIds, setSelectedRelationshipIds] = useState<
         string[]
@@ -245,14 +243,12 @@ export const Canvas: React.FC<CanvasProps> = ({
         useState(false);
     const {
         reorderTables,
-        fitView,
         setOverlapGraph,
         overlapGraph,
         showFilter,
         setShowFilter,
     } = useCanvas();
     const { filter, loading: filterLoading } = useDiagramFilter();
-    const { focusOnTable } = useFocusOn();
 
     const [isInitialLoadingNodes, setIsInitialLoadingNodes] = useState(true);
 
@@ -305,7 +301,7 @@ export const Canvas: React.FC<CanvasProps> = ({
     }, [isInitialLoadingNodes, fitView, focusTableId]);
 
     useEffect(() => {
-        if (!focusTableId) {
+        if (!clean || !focusTableId) {
             return;
         }
         let frame = 0;
@@ -315,14 +311,23 @@ export const Canvas: React.FC<CanvasProps> = ({
                 frame = requestAnimationFrame(center);
                 return;
             }
-            focusOnTable(focusTableId, { select: false, duration: 0 });
+            fitView({
+                nodes: [
+                    {
+                        id: focusTableId,
+                    },
+                ],
+                duration: 0,
+                padding: 0.1,
+                maxZoom: 1,
+            });
         };
         frame = requestAnimationFrame(center);
         return () => cancelAnimationFrame(frame);
-    }, [focusTableId, getInternalNode, focusOnTable]);
+    }, [clean, focusTableId, getInternalNode, fitView]);
 
     useEffect(() => {
-        if (focusTableId) {
+        if (clean && focusTableId) {
             setEdges([]);
             return;
         }
@@ -369,7 +374,14 @@ export const Canvas: React.FC<CanvasProps> = ({
                 })
             ),
         ]);
-    }, [relationships, dependencies, setEdges, showDBViews, focusTableId]);
+    }, [
+        relationships,
+        dependencies,
+        setEdges,
+        showDBViews,
+        focusTableId,
+        clean,
+    ]);
 
     useEffect(() => {
         const selectedNodesIds = nodes


### PR DESCRIPTION
## Summary
- center and fit canvas on selected table when clean mode passes table id using React Flow's `fitView`
- limit centering and edge removal to clean mode only

## Testing
- `npm run lint`
- `npm test` *(Error parsing CREATE TABLE statement)*
- `NODE_OPTIONS=--max_old_space_size=4096 npx tsc -p tsconfig.json --noEmit`
- `npm run build` *(JavaScript heap out of memory)*

------
https://chatgpt.com/codex/tasks/task_e_68bd2ddd27fc832c8f612baacf1d48d9