### PR TITLE
Center table in clean mode

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -375,6 +375,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         setEdges([]);
 
         let frame = 0;
+        let timeoutId: ReturnType<typeof setTimeout>;
         const center = () => {
             const node = getInternalNode(focusTableId);
             if (!node?.width || !node?.height) {
@@ -382,10 +383,13 @@ export const Canvas: React.FC<CanvasProps> = ({
                 return;
             }
             focusOnTable(focusTableId, { select: false, duration: 50 });
-            setLockCanvas(true);
+            timeoutId = setTimeout(() => setLockCanvas(true), 60);
         };
         frame = requestAnimationFrame(center);
-        return () => cancelAnimationFrame(frame);
+        return () => {
+            cancelAnimationFrame(frame);
+            clearTimeout(timeoutId);
+        };
         // eslint-disable-next-line react-hooks/exhaustive-deps
     }, [clean, focusTableId, getInternalNode, setEdges, setLockCanvas]);
 


### PR DESCRIPTION
## Summary
- ensure requested table centers in clean mode by deferring canvas lock

## Testing
- `npm test` *(fails: MySQL default values parsing error? Wait we had fail? In log earlier we saw an error? Actually we saw an error but tests passed; hmm.*
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68bf07cf6f10832c93f27b3ca20d407a