### PR TITLE
feat: add table share links V4

### DIFF
--- a/src/context/dialog-context/dialog-context.tsx
+++ b/src/context/dialog-context/dialog-context.tsx
@@ -10,6 +10,7 @@ import type { CreateRelationshipDialogProps } from '@/dialogs/create-relationshi
 import type { ImportDBMLDialogProps } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
 import type { OpenDiagramDialogProps } from '@/dialogs/open-diagram-dialog/open-diagram-dialog';
 import type { CreateDiagramDialogProps } from '@/dialogs/create-diagram-dialog/create-diagram-dialog';
+import type { ShareTableDialogProps } from '@/dialogs/share-table-dialog/share-table-dialog';
 
 export interface DialogContext {
     // Create diagram dialog
@@ -73,6 +74,12 @@ export interface DialogContext {
         params?: Omit<ImportDBMLDialogProps, 'dialog'>
     ) => void;
     closeImportDBMLDialog: () => void;
+
+    // Share table dialog
+    openShareTableDialog: (
+        params: Omit<ShareTableDialogProps, 'dialog'>
+    ) => void;
+    closeShareTableDialog: () => void;
 }
 
 export const dialogContext = createContext<DialogContext>({
@@ -98,4 +105,6 @@ export const dialogContext = createContext<DialogContext>({
     closeImportDiagramDialog: emptyFn,
     openImportDBMLDialog: emptyFn,
     closeImportDBMLDialog: emptyFn,
+    openShareTableDialog: emptyFn,
+    closeShareTableDialog: emptyFn,
 });

--- a/src/context/dialog-context/dialog-provider.tsx
+++ b/src/context/dialog-context/dialog-provider.tsx
@@ -22,6 +22,8 @@ import { ExportDiagramDialog } from '@/dialogs/export-diagram-dialog/export-diag
 import { ImportDiagramDialog } from '@/dialogs/import-diagram-dialog/import-diagram-dialog';
 import type { ImportDBMLDialogProps } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
 import { ImportDBMLDialog } from '@/dialogs/import-dbml-dialog/import-dbml-dialog';
+import type { ShareTableDialogProps } from '@/dialogs/share-table-dialog/share-table-dialog';
+import { ShareTableDialog } from '@/dialogs/share-table-dialog/share-table-dialog';
 
 export const DialogProvider: React.FC<React.PropsWithChildren> = ({
     children,
@@ -137,6 +139,19 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
     const [importDBMLDialogParams, setImportDBMLDialogParams] =
         useState<Omit<ImportDBMLDialogProps, 'dialog'>>();
 
+    // Share table dialog
+    const [openShareTableDialog, setOpenShareTableDialog] = useState(false);
+    const [shareTableDialogParams, setShareTableDialogParams] =
+        useState<Omit<ShareTableDialogProps, 'dialog'>>();
+    const openShareTableDialogHandler: DialogContext['openShareTableDialog'] =
+        useCallback(
+            (params) => {
+                setShareTableDialogParams(params);
+                setOpenShareTableDialog(true);
+            },
+            [setOpenShareTableDialog]
+        );
+
     return (
         <dialogContext.Provider
             value={{
@@ -170,6 +185,8 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
                     setOpenImportDBMLDialog(true);
                 },
                 closeImportDBMLDialog: () => setOpenImportDBMLDialog(false),
+                openShareTableDialog: openShareTableDialogHandler,
+                closeShareTableDialog: () => setOpenShareTableDialog(false),
             }}
         >
             {children}
@@ -207,6 +224,10 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
             <ImportDBMLDialog
                 dialog={{ open: openImportDBMLDialog }}
                 {...importDBMLDialogParams}
+            />
+            <ShareTableDialog
+                dialog={{ open: openShareTableDialog }}
+                {...shareTableDialogParams}
             />
         </dialogContext.Provider>
     );

--- a/src/dialogs/share-table-dialog/share-table-dialog.tsx
+++ b/src/dialogs/share-table-dialog/share-table-dialog.tsx
@@ -1,0 +1,99 @@
+import React, { useEffect, useMemo, useRef } from 'react';
+import { useDialog } from '@/hooks/use-dialog';
+import {
+    Dialog,
+    DialogContent,
+    DialogDescription,
+    DialogFooter,
+    DialogHeader,
+    DialogTitle,
+    DialogClose,
+} from '@/components/dialog/dialog';
+import type { BaseDialogProps } from '../common/base-dialog-props';
+import { useTranslation } from 'react-i18next';
+import { Input } from '@/components/input/input';
+import { Button } from '@/components/button/button';
+import { Copy } from 'lucide-react';
+import { useToast } from '@/components/toast/use-toast';
+
+export interface ShareTableDialogProps extends BaseDialogProps {
+    tableId: string;
+}
+
+export const ShareTableDialog: React.FC<ShareTableDialogProps> = ({
+    dialog,
+    tableId,
+}) => {
+    const { closeShareTableDialog } = useDialog();
+    const { t } = useTranslation();
+    const { toast } = useToast();
+    const inputRef = useRef<HTMLInputElement>(null);
+
+    const shareUrl = useMemo(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('clean', 'true');
+        url.searchParams.set('table', tableId);
+        return url.toString();
+    }, [tableId]);
+
+    useEffect(() => {
+        if (dialog.open) {
+            setTimeout(() => {
+                inputRef.current?.select();
+            }, 0);
+        }
+    }, [dialog.open]);
+
+    const handleCopy = async () => {
+        inputRef.current?.select();
+        try {
+            await navigator.clipboard.writeText(shareUrl);
+            toast({ title: t('copied') });
+        } catch {
+            // ignore error, selection already made
+        }
+    };
+
+    return (
+        <Dialog
+            {...dialog}
+            onOpenChange={(open) => {
+                if (!open) {
+                    closeShareTableDialog();
+                }
+            }}
+        >
+            <DialogContent className="sm:max-w-md">
+                <DialogHeader>
+                    <DialogTitle>{t('share_table_dialog.title')}</DialogTitle>
+                    <DialogDescription>
+                        {t('share_table_dialog.description')}
+                    </DialogDescription>
+                </DialogHeader>
+                <div className="flex items-center gap-2 py-4">
+                    <Input
+                        ref={inputRef}
+                        value={shareUrl}
+                        readOnly
+                        className="flex-1"
+                    />
+                    <Button
+                        variant="secondary"
+                        onClick={handleCopy}
+                        className="shrink-0"
+                    >
+                        <Copy className="mr-2 size-4" />
+                        {t('copy_to_clipboard')}
+                    </Button>
+                </div>
+                <DialogFooter className="sm:justify-end">
+                    <DialogClose asChild>
+                        <Button variant="outline">
+                            {t('share_table_dialog.close')}
+                        </Button>
+                    </DialogClose>
+                </DialogFooter>
+            </DialogContent>
+        </Dialog>
+    );
+};

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -113,6 +113,12 @@ export const en = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'View all Options...',
             tables_section: {

--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -16,15 +16,23 @@ import { TopNavbar } from './top-navbar/top-navbar';
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
 
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                tableId={tableId}
+            />
+        );
     }
 
     return (
@@ -52,7 +60,10 @@ export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
                         className={!isSidePanelShowed ? 'hidden' : ''}
                     />
                     <ResizablePanel defaultSize={75}>
-                        <Canvas initialTables={initialDiagram?.tables ?? []} />
+                        <Canvas
+                            initialTables={initialDiagram?.tables ?? []}
+                            tableId={tableId}
+                        />
                     </ResizablePanel>
                 </ResizablePanelGroup>
             </SidebarProvider>

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -18,14 +18,22 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    tableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
     clean,
+    tableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        return (
+            <Canvas
+                initialTables={initialDiagram?.tables ?? []}
+                clean
+                tableId={tableId}
+            />
+        );
     }
     return (
         <>
@@ -51,7 +59,10 @@ export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
                         <SidePanel data-vaul-no-drag />
                     </DrawerContent>
                 </Drawer>
-                <Canvas initialTables={initialDiagram?.tables ?? []} />
+                <Canvas
+                    initialTables={initialDiagram?.tables ?? []}
+                    tableId={tableId}
+                />
             </SidebarProvider>
         </>
     );

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -41,10 +41,12 @@ export const EditorMobileLayoutLazy = React.lazy(
 
 interface EditorPageComponentProps {
     clean?: boolean;
+    tableId?: string;
 }
 
 const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
     clean = false,
+    tableId,
 }) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
@@ -107,11 +109,13 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            tableId={tableId}
                         />
                     )}
                 </Suspense>
@@ -124,6 +128,9 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
 export const EditorPage: React.FC = () => {
     const [searchParams] = useSearchParams();
     const clean = searchParams.get('clean') === 'true';
+    const tableId = clean
+        ? (searchParams.get('table') ?? undefined)
+        : undefined;
 
     return (
         <LocalConfigProvider>
@@ -146,6 +153,9 @@ export const EditorPage: React.FC = () => {
                                                                             <EditorPageComponent
                                                                                 clean={
                                                                                     clean
+                                                                                }
+                                                                                tableId={
+                                                                                    tableId
                                                                                 }
                                                                             />
                                                                         </KeyboardShortcutsProvider>

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -10,6 +10,7 @@ import {
     Check,
     Group,
     Copy,
+    Share2,
 } from 'lucide-react';
 import { ListItemHeaderButton } from '@/pages/editor-page/side-panel/list-item-header-button/list-item-header-button';
 import type { DBTable } from '@/lib/domain/db-table';
@@ -58,7 +59,7 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
         readonly,
     } = useChartDB();
     const { schemasDisplayed } = useDiagramFilter();
-    const { openTableSchemaDialog } = useDialog();
+    const { openTableSchemaDialog, openShareTableDialog } = useDialog();
     const { t } = useTranslation();
     const { focusOnTable } = useFocusOn();
     const [editMode, setEditMode] = React.useState(false);
@@ -95,6 +96,14 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
             focusOnTable(table.id);
         },
         [focusOnTable, table.id]
+    );
+
+    const handleShareTable = useCallback(
+        (event: React.MouseEvent<HTMLButtonElement, MouseEvent>) => {
+            event.stopPropagation();
+            openShareTableDialog({ tableId: table.id });
+        },
+        [openShareTableDialog, table.id]
     );
 
     const deleteTableHandler = useCallback(() => {
@@ -311,6 +320,9 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
                             ) : null}
                             <ListItemHeaderButton onClick={handleFocusOnTable}>
                                 <CircleDotDashed />
+                            </ListItemHeaderButton>
+                            <ListItemHeaderButton onClick={handleShareTable}>
+                                <Share2 />
                             </ListItemHeaderButton>
                         </div>
                     </>


### PR DESCRIPTION
## Summary
- add dialog to copy shareable table links
- allow `clean` view to focus on a single table via URL

## Testing
- `npm test` *(fails: Error parsing CREATE TABLE statement)*
- `npm run lint:fix`


------
https://chatgpt.com/codex/tasks/task_e_68bfd45dcf6c832ca8fd6aacedf19389