### PR TITLE
feat: add table share links

### DIFF
--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -115,6 +115,8 @@ export const de: LanguageTranslation = {
         show_less: 'Weniger anzeigen',
         copy_to_clipboard: 'In die Zwischenablage kopieren',
         copied: 'Kopiert!',
+        share: 'Teilen',
+        share_table_link: 'Tabellenlink teilen',
 
         side_panel: {
             view_all_options: 'Alle Optionen anzeigen...',

--- a/src/i18n/locales/en.ts
+++ b/src/i18n/locales/en.ts
@@ -112,6 +112,8 @@ export const en = {
         show_less: 'Show Less',
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
+        share: 'Share',
+        share_table_link: 'Share Table Link',
 
         side_panel: {
             view_all_options: 'View all Options...',

--- a/src/pages/editor-page/editor-desktop-layout.tsx
+++ b/src/pages/editor-page/editor-desktop-layout.tsx
@@ -16,15 +16,26 @@ import { TopNavbar } from './top-navbar/top-navbar';
 export interface EditorDesktopLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    focusedTableId?: string;
 }
 export const EditorDesktopLayout: React.FC<EditorDesktopLayoutProps> = ({
     initialDiagram,
     clean,
+    focusedTableId,
 }) => {
     const { isSidePanelShowed } = useLayout();
 
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        const tables = focusedTableId
+            ? initialDiagram?.tables?.filter((t) => t.id === focusedTableId)
+            : (initialDiagram?.tables ?? []);
+        return (
+            <Canvas
+                initialTables={tables}
+                clean
+                focusedTableId={focusedTableId}
+            />
+        );
     }
 
     return (

--- a/src/pages/editor-page/editor-mobile-layout.tsx
+++ b/src/pages/editor-page/editor-mobile-layout.tsx
@@ -18,14 +18,25 @@ import { EditorSidebar } from './editor-sidebar/editor-sidebar';
 export interface EditorMobileLayoutProps {
     initialDiagram?: Diagram;
     clean?: boolean;
+    focusedTableId?: string;
 }
 export const EditorMobileLayout: React.FC<EditorMobileLayoutProps> = ({
     initialDiagram,
     clean,
+    focusedTableId,
 }) => {
     const { isSidePanelShowed, hideSidePanel } = useLayout();
     if (clean) {
-        return <Canvas initialTables={initialDiagram?.tables ?? []} clean />;
+        const tables = focusedTableId
+            ? initialDiagram?.tables?.filter((t) => t.id === focusedTableId)
+            : (initialDiagram?.tables ?? []);
+        return (
+            <Canvas
+                initialTables={tables}
+                clean
+                focusedTableId={focusedTableId}
+            />
+        );
     }
     return (
         <>

--- a/src/pages/editor-page/editor-page.tsx
+++ b/src/pages/editor-page/editor-page.tsx
@@ -41,10 +41,12 @@ export const EditorMobileLayoutLazy = React.lazy(
 
 interface EditorPageComponentProps {
     clean?: boolean;
+    tableId?: string;
 }
 
 const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
     clean = false,
+    tableId,
 }) => {
     const { diagramName, currentDiagram } = useChartDB();
     const { openStarUsDialog } = useDialog();
@@ -107,11 +109,13 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
                         <EditorDesktopLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            focusedTableId={tableId}
                         />
                     ) : (
                         <EditorMobileLayoutLazy
                             initialDiagram={initialDiagram}
                             clean={clean}
+                            focusedTableId={tableId}
                         />
                     )}
                 </Suspense>
@@ -124,6 +128,9 @@ const EditorPageComponent: React.FC<EditorPageComponentProps> = ({
 export const EditorPage: React.FC = () => {
     const [searchParams] = useSearchParams();
     const clean = searchParams.get('clean') === 'true';
+    const tableId = clean
+        ? (searchParams.get('table') ?? undefined)
+        : undefined;
 
     return (
         <LocalConfigProvider>
@@ -146,6 +153,9 @@ export const EditorPage: React.FC = () => {
                                                                             <EditorPageComponent
                                                                                 clean={
                                                                                     clean
+                                                                                }
+                                                                                tableId={
+                                                                                    tableId
                                                                                 }
                                                                             />
                                                                         </KeyboardShortcutsProvider>

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -10,6 +10,7 @@ import {
     Check,
     Group,
     Copy,
+    Share2,
 } from 'lucide-react';
 import { ListItemHeaderButton } from '@/pages/editor-page/side-panel/list-item-header-button/list-item-header-button';
 import type { DBTable } from '@/lib/domain/db-table';
@@ -38,6 +39,15 @@ import { cloneTable } from '@/lib/clone';
 import type { DBSchema } from '@/lib/domain';
 import { defaultSchemas } from '@/lib/data/default-schemas';
 import { useDiagramFilter } from '@/context/diagram-filter-context/use-diagram-filter';
+import {
+    Dialog,
+    DialogContent,
+    DialogHeader,
+    DialogTitle,
+    DialogDescription,
+} from '@/components/dialog/dialog';
+import { Button } from '@/components/button/button';
+import { useToast } from '@/components/toast/use-toast';
 
 export interface TableListItemHeaderProps {
     table: DBTable;
@@ -65,6 +75,31 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     const [tableName, setTableName] = React.useState(table.name);
     const inputRef = React.useRef<HTMLInputElement>(null);
     const { listeners } = useSortable({ id: table.id });
+    const { toast } = useToast();
+    const [shareDialogOpen, setShareDialogOpen] = React.useState(false);
+    const shareInputRef = React.useRef<HTMLInputElement>(null);
+
+    const shareLink = useMemo(() => {
+        const url = new URL(window.location.href);
+        url.searchParams.set('clean', 'true');
+        url.searchParams.set('table', table.id);
+        return url.toString();
+    }, [table.id]);
+
+    const openShareDialog = useCallback((e: React.MouseEvent) => {
+        e.stopPropagation();
+        setShareDialogOpen(true);
+    }, []);
+
+    const copyShareLink = useCallback(async () => {
+        shareInputRef.current?.select();
+        try {
+            await navigator.clipboard.writeText(shareLink);
+            toast({ title: t('copied') });
+        } catch {
+            // ignore
+        }
+    }, [shareLink, toast, t]);
 
     const editTableName = useCallback(() => {
         if (!editMode) return;
@@ -250,76 +285,108 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
     }, [table.name]);
 
     return (
-        <div className="group flex h-11 flex-1 items-center justify-between gap-1 overflow-hidden">
-            {!readonly ? (
-                <div
-                    className="flex cursor-move items-center justify-center"
-                    {...listeners}
-                >
-                    <GripVertical className="size-4 text-muted-foreground" />
-                </div>
-            ) : null}
-            <div className="flex min-w-0 flex-1 px-1">
-                {editMode ? (
-                    <Input
-                        ref={inputRef}
-                        autoFocus
-                        type="text"
-                        placeholder={table.name}
-                        value={tableName}
-                        onClick={(e) => e.stopPropagation()}
-                        onChange={(e) => setTableName(e.target.value)}
-                        className="h-7 w-full focus-visible:ring-0"
-                    />
-                ) : !readonly ? (
-                    <Tooltip>
-                        <TooltipTrigger asChild>
-                            <div
-                                onDoubleClick={enterEditMode}
-                                className="text-editable truncate px-2 py-0.5"
-                            >
-                                {table.name}
-                                <span className="text-xs text-muted-foreground">
-                                    {schemaToDisplay
-                                        ? ` (${schemaToDisplay})`
-                                        : ''}
-                                </span>
-                            </div>
-                        </TooltipTrigger>
-                        <TooltipContent>
-                            {t('tool_tips.double_click_to_edit')}
-                        </TooltipContent>
-                    </Tooltip>
-                ) : (
-                    <div className="truncate px-2 py-0.5">
-                        {table.name}
-                        <span className="text-xs text-muted-foreground">
-                            {schemaToDisplay ? ` (${schemaToDisplay})` : ''}
-                        </span>
+        <>
+            <div className="group flex h-11 flex-1 items-center justify-between gap-1 overflow-hidden">
+                {!readonly ? (
+                    <div
+                        className="flex cursor-move items-center justify-center"
+                        {...listeners}
+                    >
+                        <GripVertical className="size-4 text-muted-foreground" />
                     </div>
-                )}
-            </div>
-            <div className="flex flex-row-reverse">
-                {!editMode ? (
-                    <>
-                        {!readonly ? <div>{renderDropDownMenu()}</div> : null}
-                        <div className="flex flex-row-reverse md:hidden md:group-hover:flex">
-                            {!readonly ? (
-                                <ListItemHeaderButton onClick={enterEditMode}>
-                                    <Pencil />
-                                </ListItemHeaderButton>
-                            ) : null}
-                            <ListItemHeaderButton onClick={handleFocusOnTable}>
-                                <CircleDotDashed />
-                            </ListItemHeaderButton>
+                ) : null}
+                <div className="flex min-w-0 flex-1 px-1">
+                    {editMode ? (
+                        <Input
+                            ref={inputRef}
+                            autoFocus
+                            type="text"
+                            placeholder={table.name}
+                            value={tableName}
+                            onClick={(e) => e.stopPropagation()}
+                            onChange={(e) => setTableName(e.target.value)}
+                            className="h-7 w-full focus-visible:ring-0"
+                        />
+                    ) : !readonly ? (
+                        <Tooltip>
+                            <TooltipTrigger asChild>
+                                <div
+                                    onDoubleClick={enterEditMode}
+                                    className="text-editable truncate px-2 py-0.5"
+                                >
+                                    {table.name}
+                                    <span className="text-xs text-muted-foreground">
+                                        {schemaToDisplay
+                                            ? ` (${schemaToDisplay})`
+                                            : ''}
+                                    </span>
+                                </div>
+                            </TooltipTrigger>
+                            <TooltipContent>
+                                {t('tool_tips.double_click_to_edit')}
+                            </TooltipContent>
+                        </Tooltip>
+                    ) : (
+                        <div className="truncate px-2 py-0.5">
+                            {table.name}
+                            <span className="text-xs text-muted-foreground">
+                                {schemaToDisplay ? ` (${schemaToDisplay})` : ''}
+                            </span>
                         </div>
-                    </>
-                ) : (
-                    <ListItemHeaderButton onClick={editTableName}>
-                        <Check />
-                    </ListItemHeaderButton>
-                )}
+                    )}
+                </div>
+                <div className="flex flex-row-reverse">
+                    {!editMode ? (
+                        <>
+                            {!readonly ? (
+                                <div>{renderDropDownMenu()}</div>
+                            ) : null}
+                            <div className="flex flex-row-reverse md:hidden md:group-hover:flex">
+                                {!readonly ? (
+                                    <ListItemHeaderButton
+                                        onClick={enterEditMode}
+                                    >
+                                        <Pencil />
+                                    </ListItemHeaderButton>
+                                ) : null}
+                                <ListItemHeaderButton
+                                    onClick={handleFocusOnTable}
+                                >
+                                    <CircleDotDashed />
+                                </ListItemHeaderButton>
+                                <ListItemHeaderButton onClick={openShareDialog}>
+                                    <Share2 />
+                                </ListItemHeaderButton>
+                            </div>
+                        </>
+                    ) : (
+                        <ListItemHeaderButton onClick={editTableName}>
+                            <Check />
+                        </ListItemHeaderButton>
+                    )}
+                </div>
             </div>
-        </div>
+            <Dialog open={shareDialogOpen} onOpenChange={setShareDialogOpen}>
+                <DialogContent className="sm:max-w-md">
+                    <DialogHeader>
+                        <DialogTitle>{t('share_table_link')}</DialogTitle>
+                        <DialogDescription>
+                            {t('copy_to_clipboard')}
+                        </DialogDescription>
+                    </DialogHeader>
+                    <div className="flex items-center space-x-2">
+                        <Input
+                            ref={shareInputRef}
+                            value={shareLink}
+                            readOnly
+                            className="flex-1"
+                        />
+                        <Button variant="secondary" onClick={copyShareLink}>
+                            <Copy className="size-4" />
+                        </Button>
+                    </div>
+                </DialogContent>
+            </Dialog>
+        </>
     );
 };


### PR DESCRIPTION
## Summary
- add share button for table list items to copy clean table URLs
- support optional `table` query parameter in clean mode to focus on single table
- hide non-target nodes and edges when table is specified

## Testing
- `npm run lint`
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_68bfd45dcf6c832ca8fd6aacedf19389