### PR TITLE
Add share table dialog translations and refine copy button

### DIFF
--- a/src/context/dialog-context/dialog-provider.tsx
+++ b/src/context/dialog-context/dialog-provider.tsx
@@ -141,8 +141,9 @@ export const DialogProvider: React.FC<React.PropsWithChildren> = ({
 
     // Share table dialog
     const [openShareTableDialog, setOpenShareTableDialog] = useState(false);
-    const [shareTableDialogParams, setShareTableDialogParams] =
-        useState<Omit<ShareTableDialogProps, 'dialog'>>();
+    const [shareTableDialogParams, setShareTableDialogParams] = useState<
+        Omit<ShareTableDialogProps, 'dialog'>
+    >({ tableId: '' });
     const openShareTableDialogHandler: DialogContext['openShareTableDialog'] =
         useCallback(
             (params) => {

--- a/src/dialogs/share-table-dialog/share-table-dialog.tsx
+++ b/src/dialogs/share-table-dialog/share-table-dialog.tsx
@@ -14,6 +14,11 @@ import { useTranslation } from 'react-i18next';
 import { Input } from '@/components/input/input';
 import { Button } from '@/components/button/button';
 import { Copy } from 'lucide-react';
+import {
+    Tooltip,
+    TooltipContent,
+    TooltipTrigger,
+} from '@/components/tooltip/tooltip';
 import { useToast } from '@/components/toast/use-toast';
 
 export interface ShareTableDialogProps extends BaseDialogProps {
@@ -63,7 +68,7 @@ export const ShareTableDialog: React.FC<ShareTableDialogProps> = ({
                 }
             }}
         >
-            <DialogContent className="sm:max-w-md">
+            <DialogContent className="sm:max-w-xl">
                 <DialogHeader>
                     <DialogTitle>{t('share_table_dialog.title')}</DialogTitle>
                     <DialogDescription>
@@ -75,16 +80,22 @@ export const ShareTableDialog: React.FC<ShareTableDialogProps> = ({
                         ref={inputRef}
                         value={shareUrl}
                         readOnly
-                        className="flex-1"
+                        className="min-w-[400px] flex-1"
                     />
-                    <Button
-                        variant="secondary"
-                        onClick={handleCopy}
-                        className="shrink-0"
-                    >
-                        <Copy className="mr-2 size-4" />
-                        {t('copy_to_clipboard')}
-                    </Button>
+                    <Tooltip>
+                        <TooltipTrigger asChild>
+                            <Button
+                                variant="secondary"
+                                onClick={handleCopy}
+                                className="shrink-0 p-2"
+                            >
+                                <Copy className="size-4" />
+                            </Button>
+                        </TooltipTrigger>
+                        <TooltipContent>
+                            {t('copy_to_clipboard')}
+                        </TooltipContent>
+                    </Tooltip>
                 </div>
                 <DialogFooter className="sm:justify-end">
                     <DialogClose asChild>

--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -114,6 +114,12 @@ export const ar: LanguageTranslation = {
         copy_to_clipboard: 'نسخ إلى الحافظة',
         copied: '!تم النسخ',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: '...عرض جميع الخيارات',
             tables_section: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -115,6 +115,12 @@ export const bn: LanguageTranslation = {
         copy_to_clipboard: 'ক্লিপবোর্ডে অনুলিপি করুন',
         copied: 'অনুলিপি সম্পন্ন!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'সমস্ত বিকল্প দেখুন...',
             tables_section: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -116,6 +116,12 @@ export const de: LanguageTranslation = {
         copy_to_clipboard: 'In die Zwischenablage kopieren',
         copied: 'Kopiert!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Alle Optionen anzeigen...',
             tables_section: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -114,6 +114,12 @@ export const es: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Ver todas las opciones...',
             tables_section: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -113,6 +113,12 @@ export const fr: LanguageTranslation = {
         copy_to_clipboard: 'Copier dans le presse-papiers',
         copied: 'Copié !',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Voir toutes les Options...',
             tables_section: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -115,6 +115,12 @@ export const gu: LanguageTranslation = {
         copy_to_clipboard: 'ક્લિપબોર્ડમાં નકલ કરો',
         copied: 'નકલ થયું!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'બધા વિકલ્પો જુઓ...',
             tables_section: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -115,6 +115,12 @@ export const hi: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'सभी विकल्प देखें...',
             tables_section: {

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -113,6 +113,12 @@ export const hr: LanguageTranslation = {
         copy_to_clipboard: 'Kopiraj u međuspremnik',
         copied: 'Kopirano!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Prikaži sve opcije...',
             tables_section: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -114,6 +114,12 @@ export const id_ID: LanguageTranslation = {
         copy_to_clipboard: 'Salin ke Clipboard',
         copied: 'Tersalin!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Tampilkan Semua Pilihan...',
             tables_section: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -118,6 +118,12 @@ export const ja: LanguageTranslation = {
         copy_to_clipboard: 'Copy to Clipboard',
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'すべてのオプションを表示...',
             tables_section: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -114,6 +114,12 @@ export const ko_KR: LanguageTranslation = {
         copy_to_clipboard: '클립보드에 복사',
         copied: '복사됨!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: '전체 옵션 보기...',
             tables_section: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -117,6 +117,12 @@ export const mr: LanguageTranslation = {
         // TODO: Add translations
         copied: 'Copied!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'सर्व पर्याय पहा...',
             tables_section: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -115,6 +115,12 @@ export const ne: LanguageTranslation = {
         copy_to_clipboard: 'क्लिपबोर्डमा प्रतिलिपि गर्नुहोस्',
         copied: 'प्रतिलिपि गरियो!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'सबै विकल्पहरू हेर्नुहोस्',
             tables_section: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -115,6 +115,12 @@ export const pt_BR: LanguageTranslation = {
         copy_to_clipboard: 'Copiar para a Área de Transferência',
         copied: 'Copiado!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Ver todas as Opções...',
             tables_section: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -493,6 +493,13 @@ export const ru: LanguageTranslation = {
 
         copy_to_clipboard: 'Скопировать в буфер обмена',
         copied: 'Скопировано!',
+
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         snap_to_grid_tooltip: 'Выравнивание по сетке (Удерживайте {{key}})',
         tool_tips: {
             double_click_to_edit: 'Кликните дважды, чтобы изменить',

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -115,6 +115,12 @@ export const te: LanguageTranslation = {
         copy_to_clipboard: 'క్లిప్బోర్డుకు కాపీ చేయండి',
         copied: 'కాపీ చేయబడింది!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'అన్ని ఎంపికలను చూడండి...',
             tables_section: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -114,6 +114,13 @@ export const tr: LanguageTranslation = {
         show_less: 'Daha Az Göster',
         copy_to_clipboard: 'Panoya Kopyala',
         copied: 'Kopyalandı!',
+
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Tüm Seçenekleri Gör...',
             tables_section: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -113,6 +113,12 @@ export const uk: LanguageTranslation = {
         copy_to_clipboard: 'Копіювати в буфер обміну',
         copied: 'Скопійовано!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Переглянути всі параметри…',
             tables_section: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -114,6 +114,12 @@ export const vi: LanguageTranslation = {
         copy_to_clipboard: 'Sao chép vào bảng tạm',
         copied: 'Đã sao chép!',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: 'Xem tất cả tùy chọn...',
             tables_section: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -111,6 +111,12 @@ export const zh_CN: LanguageTranslation = {
         copy_to_clipboard: '复制到剪切板',
         copied: '复制了！',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: '查看所有选项...',
             tables_section: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -111,6 +111,12 @@ export const zh_TW: LanguageTranslation = {
         copy_to_clipboard: '複製到剪貼簿',
         copied: '已複製！',
 
+        share_table_dialog: {
+            title: 'Share Table',
+            description: 'Copy the link below to share this table.',
+            close: 'Close',
+        },
+
         side_panel: {
             view_all_options: '顯示所有選項...',
             tables_section: {

--- a/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
+++ b/src/pages/editor-page/side-panel/tables-section/table-list/table-list-item/table-list-item-header/table-list-item-header.tsx
@@ -313,6 +313,9 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
                     <>
                         {!readonly ? <div>{renderDropDownMenu()}</div> : null}
                         <div className="flex flex-row-reverse md:hidden md:group-hover:flex">
+                            <ListItemHeaderButton onClick={handleShareTable}>
+                                <Share2 />
+                            </ListItemHeaderButton>
                             {!readonly ? (
                                 <ListItemHeaderButton onClick={enterEditMode}>
                                     <Pencil />
@@ -320,9 +323,6 @@ export const TableListItemHeader: React.FC<TableListItemHeaderProps> = ({
                             ) : null}
                             <ListItemHeaderButton onClick={handleFocusOnTable}>
                                 <CircleDotDashed />
-                            </ListItemHeaderButton>
-                            <ListItemHeaderButton onClick={handleShareTable}>
-                                <Share2 />
                             </ListItemHeaderButton>
                         </div>
                     </>


### PR DESCRIPTION
## Summary
- avoid undefined table id when opening ShareTableDialog
- add placeholder share_table_dialog translations for all locales
- replace copy button text with tooltip and widen URL field
- move table share icon next to the actions menu

## Testing
- `npm run lint`
- `npx tsc -b`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c0339f897c832ca9f36dc607723782