### PR TITLE
Localize mini map labels across translations

### DIFF
--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -41,9 +41,8 @@ export const ar: LanguageTranslation = {
                 theme: 'المظهر',
                 show_dependencies: 'إظهار الاعتمادات',
                 hide_dependencies: 'إخفاء الاعتمادات',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'إظهار الخريطة المصغرة',
+                hide_minimap: 'إخفاء الخريطة المصغرة',
             },
             backup: {
                 backup: 'النسخ الاحتياطي',

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -41,9 +41,8 @@ export const bn: LanguageTranslation = {
                 theme: 'থিম',
                 show_dependencies: 'নির্ভরতাগুলি দেখান',
                 hide_dependencies: 'নির্ভরতাগুলি লুকান',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'মিনি মানচিত্র দেখান',
+                hide_minimap: 'মিনি মানচিত্র লুকান',
             },
 
             backup: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -41,9 +41,8 @@ export const de: LanguageTranslation = {
                 theme: 'Stil',
                 show_dependencies: 'Abhängigkeiten anzeigen',
                 hide_dependencies: 'Abhängigkeiten ausblenden',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mini-Karte anzeigen',
+                hide_minimap: 'Mini-Karte ausblenden',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/es.ts
+++ b/src/i18n/locales/es.ts
@@ -41,9 +41,8 @@ export const es: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar dependencias',
                 hide_dependencies: 'Ocultar dependencias',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mostrar minimapa',
+                hide_minimap: 'Ocultar minimapa',
             },
             backup: {
                 backup: 'Respaldo',

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -41,9 +41,8 @@ export const gu: LanguageTranslation = {
                 theme: 'થિમ',
                 show_dependencies: 'નિર્ભરતાઓ બતાવો',
                 hide_dependencies: 'નિર્ભરતાઓ છુપાવો',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'મિની નકશો બતાવો',
+                hide_minimap: 'મિની નકશો છુપાવો',
             },
 
             backup: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -41,9 +41,8 @@ export const hi: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'निर्भरता दिखाएँ',
                 hide_dependencies: 'निर्भरता छिपाएँ',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी मानचित्र दिखाएं',
+                hide_minimap: 'मिनी मानचित्र छिपाएं',
             },
             backup: {
                 backup: 'बैकअप',

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -41,9 +41,8 @@ export const id_ID: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Tampilkan Dependensi',
                 hide_dependencies: 'Sembunyikan Dependensi',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Tampilkan Peta Mini',
+                hide_minimap: 'Sembunyikan Peta Mini',
             },
             backup: {
                 backup: 'Cadangan',

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -42,9 +42,8 @@ export const ja: LanguageTranslation = {
                 // TODO: Translate
                 show_dependencies: 'Show Dependencies',
                 hide_dependencies: 'Hide Dependencies',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'ミニマップを表示',
+                hide_minimap: 'ミニマップを非表示',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -41,9 +41,8 @@ export const ko_KR: LanguageTranslation = {
                 theme: '테마',
                 show_dependencies: '종속성 보이기',
                 hide_dependencies: '종속성 숨기기',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '미니 맵 표시',
+                hide_minimap: '미니 맵 숨기기',
             },
             backup: {
                 backup: '백업',

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -41,9 +41,8 @@ export const mr: LanguageTranslation = {
                 theme: 'थीम',
                 show_dependencies: 'डिपेंडेन्सि दाखवा',
                 hide_dependencies: 'डिपेंडेन्सि लपवा',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी नकाशा दाखवा',
+                hide_minimap: 'मिनी नकाशा लपवा',
             },
             backup: {
                 // TODO: Add translations

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -41,9 +41,8 @@ export const ne: LanguageTranslation = {
                 theme: 'थिम',
                 show_dependencies: 'डिपेन्डेन्सीहरू देखाउनुहोस्',
                 hide_dependencies: 'डिपेन्डेन्सीहरू लुकाउनुहोस्',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'मिनी नक्शा देखाउनुहोस्',
+                hide_minimap: 'मिनी नक्शा लुकाउनुहोस्',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -41,9 +41,8 @@ export const pt_BR: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Mostrar Dependências',
                 hide_dependencies: 'Ocultar Dependências',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mostrar Mini Mapa',
+                hide_minimap: 'Ocultar Mini Mapa',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -41,9 +41,8 @@ export const te: LanguageTranslation = {
                 theme: 'థీమ్',
                 show_dependencies: 'ఆధారాలు చూపించండి',
                 hide_dependencies: 'ఆధారాలను దాచండి',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'మినీ మ్యాప్ చూపించు',
+                hide_minimap: 'మినీ మ్యాప్ దాచు',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -41,9 +41,8 @@ export const tr: LanguageTranslation = {
                 theme: 'Tema',
                 show_dependencies: 'Bağımlılıkları Göster',
                 hide_dependencies: 'Bağımlılıkları Gizle',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Mini Haritayı Göster',
+                hide_minimap: 'Mini Haritayı Gizle',
             },
             // TODO: Translate
             backup: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -41,9 +41,8 @@ export const vi: LanguageTranslation = {
                 theme: 'Chủ đề',
                 show_dependencies: 'Hiển thị các phụ thuộc',
                 hide_dependencies: 'Ẩn các phụ thuộc',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: 'Hiển thị bản đồ nhỏ',
+                hide_minimap: 'Ẩn bản đồ nhỏ',
             },
             backup: {
                 backup: 'Hỗ trợ',

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -41,9 +41,8 @@ export const zh_CN: LanguageTranslation = {
                 theme: '主题',
                 show_dependencies: '展示依赖',
                 hide_dependencies: '隐藏依赖',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '显示小地图',
+                hide_minimap: '隐藏小地图',
             },
             backup: {
                 backup: '备份',

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -41,9 +41,8 @@ export const zh_TW: LanguageTranslation = {
                 theme: '主題',
                 show_dependencies: '顯示相依性',
                 hide_dependencies: '隱藏相依性',
-                // TODO: Translate
-                show_minimap: 'Show Mini Map',
-                hide_minimap: 'Hide Mini Map',
+                show_minimap: '顯示小地圖',
+                hide_minimap: '隱藏小地圖',
             },
             backup: {
                 backup: '備份',


### PR DESCRIPTION
## Summary
- Localize "Show/Hide Mini Map" strings for all non-English locales
- Remove placeholder TODO comments for these entries

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c04b7d8758832c887384a06fc8c21a