### PR TITLE
Expand single table in clean mode

### DIFF
--- a/src/pages/editor-page/canvas/canvas.tsx
+++ b/src/pages/editor-page/canvas/canvas.tsx
@@ -215,6 +215,7 @@ export const Canvas: React.FC<CanvasProps> = ({
         relationships,
         createRelationship,
         createDependency,
+        updateTable,
         updateTablesState,
         removeRelationships,
         removeDependencies,
@@ -303,9 +304,13 @@ export const Canvas: React.FC<CanvasProps> = ({
             const node = getNode(tableId);
             if (node) {
                 focusOnTable(tableId, { select: false });
+                const tableNode = node as TableNodeType;
+                if (!tableNode.data.table.expanded) {
+                    updateTable(tableId, { expanded: true });
+                }
             }
         }
-    }, [clean, tableId, nodes, focusOnTable, getNode]);
+    }, [clean, tableId, nodes, focusOnTable, getNode, updateTable]);
 
     useEffect(() => {
         const targetIndexes: Record<string, number> = relationships.reduce(


### PR DESCRIPTION
## Summary
- Expand the table when opening a single table in clean mode.

## Testing
- `npm run test:ci`

------
https://chatgpt.com/codex/tasks/task_e_68c092700b7c832c81870431fd2628fd