### PR TITLE
Add translations for start-new diagram button

### DIFF
--- a/src/i18n/locales/ar.ts
+++ b/src/i18n/locales/ar.ts
@@ -321,7 +321,7 @@ export const ar: LanguageTranslation = {
                 tables_count: 'الجداول',
             },
             cancel: 'إلغاء',
-            start_new: 'Start with a new diagram',
+            start_new: 'ابدأ بمخطط جديد',
             open: 'فتح',
 
             diagram_actions: {

--- a/src/i18n/locales/bn.ts
+++ b/src/i18n/locales/bn.ts
@@ -325,7 +325,7 @@ export const bn: LanguageTranslation = {
                 tables_count: 'টেবিল',
             },
             cancel: 'বাতিল করুন',
-            start_new: 'Start with a new diagram',
+            start_new: 'নতুন ডায়াগ্রাম দিয়ে শুরু করুন',
             open: 'খুলুন',
 
             diagram_actions: {

--- a/src/i18n/locales/de.ts
+++ b/src/i18n/locales/de.ts
@@ -325,7 +325,7 @@ export const de: LanguageTranslation = {
                 tables_count: 'Tabellen',
             },
             cancel: 'Abbrechen',
-            start_new: 'Start with a new diagram',
+            start_new: 'Mit einem neuen Diagramm starten',
             open: 'Öffnen',
 
             diagram_actions: {

--- a/src/i18n/locales/fr.ts
+++ b/src/i18n/locales/fr.ts
@@ -324,7 +324,7 @@ export const fr: LanguageTranslation = {
                 tables_count: 'Tables',
             },
             cancel: 'Annuler',
-            start_new: 'Start with a new diagram',
+            start_new: 'Commencer avec un nouveau diagramme',
             open: 'Ouvrir',
 
             diagram_actions: {

--- a/src/i18n/locales/gu.ts
+++ b/src/i18n/locales/gu.ts
@@ -324,7 +324,7 @@ export const gu: LanguageTranslation = {
                 tables_count: 'ટેબલ્સ',
             },
             cancel: 'રદ કરો',
-            start_new: 'Start with a new diagram',
+            start_new: 'નવા આલેખ સાથે પ્રારંભ કરો',
             open: 'ખોલો',
 
             diagram_actions: {

--- a/src/i18n/locales/hi.ts
+++ b/src/i18n/locales/hi.ts
@@ -322,7 +322,7 @@ export const hi: LanguageTranslation = {
                 tables_count: 'तालिकाएँ',
             },
             cancel: 'रद्द करें',
-            start_new: 'Start with a new diagram',
+            start_new: 'एक नए आरेख से शुरू करें',
             open: 'खोलें',
 
             diagram_actions: {

--- a/src/i18n/locales/hr.ts
+++ b/src/i18n/locales/hr.ts
@@ -327,7 +327,7 @@ export const hr: LanguageTranslation = {
                 tables_count: 'Tablice',
             },
             cancel: 'Odustani',
-            start_new: 'Start with a new diagram',
+            start_new: 'Započni s novim dijagramom',
             open: 'Otvori',
 
             diagram_actions: {

--- a/src/i18n/locales/id_ID.ts
+++ b/src/i18n/locales/id_ID.ts
@@ -325,7 +325,7 @@ export const id_ID: LanguageTranslation = {
                 tables_count: 'Tabel',
             },
             cancel: 'Batal',
-            start_new: 'Start with a new diagram',
+            start_new: 'Mulai dengan diagram baru',
             open: 'Buka',
 
             diagram_actions: {

--- a/src/i18n/locales/ja.ts
+++ b/src/i18n/locales/ja.ts
@@ -324,7 +324,7 @@ export const ja: LanguageTranslation = {
                 tables_count: 'テーブル数',
             },
             cancel: 'キャンセル',
-            start_new: 'Start with a new diagram',
+            start_new: '新しいダイアグラムで開始',
             open: '開く',
 
             diagram_actions: {

--- a/src/i18n/locales/ko_KR.ts
+++ b/src/i18n/locales/ko_KR.ts
@@ -321,7 +321,7 @@ export const ko_KR: LanguageTranslation = {
                 tables_count: '테이블 갯수',
             },
             cancel: '취소',
-            start_new: 'Start with a new diagram',
+            start_new: '새 다이어그램으로 시작',
             open: '열기',
 
             diagram_actions: {

--- a/src/i18n/locales/mr.ts
+++ b/src/i18n/locales/mr.ts
@@ -324,7 +324,7 @@ export const mr: LanguageTranslation = {
                 tables_count: 'टेबल्स',
             },
             cancel: 'रद्द करा',
-            start_new: 'Start with a new diagram',
+            start_new: 'नवीन आरेखासह प्रारंभ करा',
             open: 'उघडा',
 
             diagram_actions: {

--- a/src/i18n/locales/ne.ts
+++ b/src/i18n/locales/ne.ts
@@ -324,7 +324,7 @@ export const ne: LanguageTranslation = {
                 tables_count: 'तालिकाहरू',
             },
             cancel: 'रद्द गर्नुहोस्',
-            start_new: 'Start with a new diagram',
+            start_new: 'नयाँ डायाग्रामबाट सुरु गर्नुहोस्',
             open: 'खोल्नुहोस्',
 
             diagram_actions: {

--- a/src/i18n/locales/pt_BR.ts
+++ b/src/i18n/locales/pt_BR.ts
@@ -323,7 +323,7 @@ export const pt_BR: LanguageTranslation = {
                 tables_count: 'Tabelas',
             },
             cancel: 'Cancelar',
-            start_new: 'Start with a new diagram',
+            start_new: 'Começar com um novo diagrama',
             open: 'Abrir',
 
             diagram_actions: {

--- a/src/i18n/locales/ru.ts
+++ b/src/i18n/locales/ru.ts
@@ -321,7 +321,7 @@ export const ru: LanguageTranslation = {
                 tables_count: 'Таблицы',
             },
             cancel: 'Отмена',
-            start_new: 'Start with a new diagram',
+            start_new: 'Начать с новой диаграммы',
             open: 'Открыть',
 
             diagram_actions: {

--- a/src/i18n/locales/te.ts
+++ b/src/i18n/locales/te.ts
@@ -323,7 +323,7 @@ export const te: LanguageTranslation = {
                 tables_count: 'పట్టికలు',
             },
             cancel: 'రద్దు',
-            start_new: 'Start with a new diagram',
+            start_new: 'కొత్త డయాగ్రామ్‌తో ప్రారంభించండి',
             open: 'తెరవు',
 
             diagram_actions: {

--- a/src/i18n/locales/tr.ts
+++ b/src/i18n/locales/tr.ts
@@ -317,7 +317,7 @@ export const tr: LanguageTranslation = {
                 tables_count: 'Tablolar',
             },
             cancel: 'İptal',
-            start_new: 'Start with a new diagram',
+            start_new: 'Yeni bir diyagramla başlayın',
             open: 'Aç',
 
             diagram_actions: {

--- a/src/i18n/locales/uk.ts
+++ b/src/i18n/locales/uk.ts
@@ -326,7 +326,7 @@ export const uk: LanguageTranslation = {
                 tables_count: 'Таблиці',
             },
             cancel: 'Скасувати',
-            start_new: 'Start with a new diagram',
+            start_new: 'Почати з нової діаграми',
             open: 'Відкрити',
 
             diagram_actions: {

--- a/src/i18n/locales/vi.ts
+++ b/src/i18n/locales/vi.ts
@@ -323,7 +323,7 @@ export const vi: LanguageTranslation = {
                 tables_count: 'Số bảng',
             },
             cancel: 'Hủy',
-            start_new: 'Start with a new diagram',
+            start_new: 'Bắt đầu với sơ đồ mới',
             open: 'Mở',
 
             diagram_actions: {

--- a/src/i18n/locales/zh_CN.ts
+++ b/src/i18n/locales/zh_CN.ts
@@ -315,7 +315,7 @@ export const zh_CN: LanguageTranslation = {
                 tables_count: '表数量',
             },
             cancel: '取消',
-            start_new: 'Start with a new diagram',
+            start_new: '从新图表开始',
             open: '打开',
 
             diagram_actions: {

--- a/src/i18n/locales/zh_TW.ts
+++ b/src/i18n/locales/zh_TW.ts
@@ -315,7 +315,7 @@ export const zh_TW: LanguageTranslation = {
                 tables_count: '表格數',
             },
             cancel: '取消',
-            start_new: 'Start with a new diagram',
+            start_new: '從新圖表開始',
             open: '開啟',
 
             diagram_actions: {


### PR DESCRIPTION
## Summary
- Localize "Start with a new diagram" across all supported languages

## Testing
- `npm test`
- `npm run lint`


------
https://chatgpt.com/codex/tasks/task_e_68c11f2f4778832c92d53dd7f8fd85fc